### PR TITLE
Implement #10 full path endpoints

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.1.{build}
 image:
 - Visual Studio 2017
-- Ubuntu
+# - Ubuntu
 
 build:
   verbosity: minimal
@@ -35,9 +35,9 @@ for:
 - branches:
     only:
     - master
-  matrix:
-    only:
-    - image: Visual Studio 2017
+  # matrix:
+  #   only:
+  #   - image: Visual Studio 2017
   artifacts:
   - path: build\*.nupkg
     name: nuget
@@ -46,8 +46,10 @@ for:
 
 # Only use cache on Windows build
 # (AV caches for each matrix item separately, and the cache is too large)
-- matrix:
-    only:
-    - image: Visual Studio 2017
-  cache:
-  - .nuget
+# - matrix:
+#     only:
+#     - image: Visual Studio 2017
+#   cache:
+#   - .nuget
+cache:
+- .nuget

--- a/build.fsx
+++ b/build.fsx
@@ -169,8 +169,8 @@ let uploadTests (url: string) =
 
 Target.description "Run the unit tests"
 Target.create "test" (fun o ->
-    dotnet' "tests/Unit" [] "test" "--logger:trx %s" (buildArgs o)
-    Option.iter uploadTests (testUploadUrl o)
+    try dotnet' "tests/Unit" [] "test" "--logger:trx %s" (buildArgs o)
+    finally Option.iter uploadTests (testUploadUrl o)
 )
 
 Target.description "Run the unit tests waiting for a debugger to connect"

--- a/src/Bolero/Router.fs
+++ b/src/Bolero/Router.fs
@@ -279,7 +279,10 @@ module private RouterImpl =
         if ty = typeof<string> then
             ty, Rest(
                 Seq.cast<string> >> String.concat "/" >> box,
-                fun s -> (unbox<string> s).Split('/') |> Seq.cast<obj>
+                fun s ->
+                    match unbox<string> s with
+                    | "" -> Seq.empty
+                    | s -> s.Split('/') |> Seq.cast<obj>
             )
         elif ty.IsArray && ty.GetArrayRank() = 1 then
             let elt = ty.GetElementType()

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -30,7 +30,7 @@ open System.Net.Http
 type Page =
     | [<EndPoint "/">] Form
     | [<EndPoint "/collection">] Collection
-    | [<EndPoint "/collection-item">] Item of key: int
+    | [<EndPoint "/collection-item/{key}">] Item of key: int
 
 type Item =
     {

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -1,6 +1,7 @@
 namespace Bolero.Tests.Web
 
 open System.Threading
+open FSharp.Reflection
 open NUnit.Framework
 open OpenQA.Selenium
 
@@ -8,6 +9,7 @@ open OpenQA.Selenium
 [<Category "Routing">]
 module Routing =
     open Bolero
+    open System.Collections.Generic
 
     let elt = NodeFixture()
 
@@ -46,14 +48,19 @@ module Routing =
         res |> Option.iter (fun res -> Assert.AreEqual(resCls, res.Text))
         Assert.AreEqual(WebFixture.Url + url, WebFixture.Driver.Url)
 
-    let failingRouter<'T>() =
-        TestCaseData(fun () -> Router.infer<'T, _, _> id id |> ignore)
+    let failingRouter<'T> (expectedError: UnionCaseInfo[] -> InvalidRouterKind) =
+        TestCaseData(
+            (fun () -> Router.infer<'T, _, _> id id |> ignore),
+            expectedError (try FSharpType.GetUnionCases typeof<'T> with _ -> [||])
+        )
             .SetArgDisplayNames(typeof<'T>.Name)
 
     type ``Invalid parameter syntax`` =
         | [<EndPoint "/{x">] X of x: string
     type ``Unknown parameter name`` =
         | [<EndPoint "/{y}">] X of x: string
+    type ``Duplicate field`` =
+        | [<EndPoint"/{x}/{x}">] X of x: string
     type ``Incomplete parameter list`` =
         | [<EndPoint "/{x}/{z}">] X of x: string * y: string * z: string
     type ``Identical paths with different parameter names`` =
@@ -61,19 +68,32 @@ module Routing =
         | [<EndPoint "/foo/{y}">] Y of y: string
     type ``Mismatched type parameters in same position`` =
         | [<EndPoint "/foo/{x}">] X of x: string
-        | [<EndPoint "/foo/{x}/y">] Y of x: int
+        | [<EndPoint "/foo/{y}/y">] Y of y: int
     type ``Rest parameter in non-final position`` =
         | [<EndPoint "/foo/{*x}/bar">] X of x: string
 
     let failingRouters = [
-        failingRouter<``Invalid parameter syntax``>()
-        failingRouter<``Unknown parameter name``>()
-        failingRouter<``Incomplete parameter list``>()
-        failingRouter<``Identical paths with different parameter names``>()
-        failingRouter<``Mismatched type parameters in same position``>()
-        failingRouter<``Rest parameter in non-final position``>()
+        failingRouter<``Invalid parameter syntax``> <| fun c ->
+            InvalidRouterKind.ParameterSyntax(c.[0], "{x")
+        failingRouter<``Unknown parameter name``> <| fun c ->
+            InvalidRouterKind.UnknownField(c.[0], "y")
+        failingRouter<``Duplicate field``> <| fun c ->
+            InvalidRouterKind.DuplicateField(c.[0], "x")
+        failingRouter<``Incomplete parameter list``> <| fun c ->
+            InvalidRouterKind.MissingField(c.[0], "y")
+        failingRouter<``Identical paths with different parameter names``> <| fun c ->
+            InvalidRouterKind.IdenticalPath(c.[1], c.[0])
+        failingRouter<``Mismatched type parameters in same position``> <| fun c ->
+            InvalidRouterKind.ParameterTypeMismatch(c.[1], "y", c.[0], "x")
+        failingRouter<``Rest parameter in non-final position``> <| fun c ->
+            InvalidRouterKind.RestNotLast(c.[0])
+        failingRouter<Dictionary<int, int>> <| fun _ ->
+            InvalidRouterKind.UnsupportedType typeof<Dictionary<int, int>>
     ]
 
     [<Test; TestCaseSource "failingRouters"; NonParallelizable>]
-    let ``Invalid routers``(makeAndIgnoreRouter: unit -> unit) =
-        Assert.Throws(fun () -> makeAndIgnoreRouter()) |> ignore
+    let ``Invalid routers``(makeAndIgnoreRouter: unit -> unit, expectedError: InvalidRouterKind) =
+        Assert.AreEqual(
+            InvalidRouter expectedError,
+            Assert.Throws<InvalidRouter>(fun () -> makeAndIgnoreRouter())
+        )

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -50,10 +50,28 @@ module Routing =
         TestCaseData(fun () -> Router.infer<'T, _, _> id id |> ignore)
             .SetArgDisplayNames(typeof<'T>.Name)
 
-    type RestNotLast = | [<EndPoint "/foo/{*x}/bar">] RestNotLast of x: string
+    type ``Invalid parameter syntax`` =
+        | [<EndPoint "/{x">] X of x: string
+    type ``Unknown parameter name`` =
+        | [<EndPoint "/{y}">] X of x: string
+    type ``Incomplete parameter list`` =
+        | [<EndPoint "/{x}/{z}">] X of x: string * y: string * z: string
+    type ``Identical paths with different parameter names`` =
+        | [<EndPoint "/foo/{x}">] X of x: string
+        | [<EndPoint "/foo/{y}">] Y of y: string
+    type ``Mismatched type parameters in same position`` =
+        | [<EndPoint "/foo/{x}">] X of x: string
+        | [<EndPoint "/foo/{x}/y">] Y of x: int
+    type ``Rest parameter in non-final position`` =
+        | [<EndPoint "/foo/{*x}/bar">] X of x: string
 
     let failingRouters = [
-        failingRouter<RestNotLast>()
+        failingRouter<``Invalid parameter syntax``>()
+        failingRouter<``Unknown parameter name``>()
+        failingRouter<``Incomplete parameter list``>()
+        failingRouter<``Identical paths with different parameter names``>()
+        failingRouter<``Mismatched type parameters in same position``>()
+        failingRouter<``Rest parameter in non-final position``>()
     ]
 
     [<Test; TestCaseSource "failingRouters"; NonParallelizable>]

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -16,7 +16,8 @@ module Routing =
 
     let links =
         App.Routing.links
-        |> List.map (fun (cls, page) ->
+        |> List.map (fun page ->
+            let cls = App.Routing.pageClass page
             TestCaseData(cls, page).SetArgDisplayNames(
                 (string page)
                     // Replace parentheses with unicode ones for nicer display in VS test explorer
@@ -27,7 +28,7 @@ module Routing =
     let ``Click link``(linkCls, page: App.Routing.Page) =
         let url = page.ExpectedUrl
         elt.ByClass("link-" + linkCls).Click()
-        let resCls = App.Routing.matchPage page
+        let resCls = App.Routing.pageClass page
         let res =
             try Some <| elt.Wait(fun () -> elt.ByClass(resCls))
             with :? WebDriverTimeoutException -> None
@@ -39,7 +40,7 @@ module Routing =
         Thread.Sleep(500) // Some cases fail without this, mainly ones with empty strings. TODO: investigate
         let url = page.ExpectedUrl
         elt.ByClass("btn-" + linkCls).Click()
-        let resCls = App.Routing.matchPage page
+        let resCls = App.Routing.pageClass page
         let res =
             try Some <| elt.Wait(fun () -> elt.ByClass(resCls))
             with :? WebDriverTimeoutException -> None

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -16,17 +16,16 @@ module Routing =
 
     let links =
         App.Routing.links
-        |> List.map (fun page ->
+        |> List.map (fun (url, page) ->
             let cls = App.Routing.pageClass page
-            TestCaseData(cls, page).SetArgDisplayNames(
+            TestCaseData(cls, url, page).SetArgDisplayNames(
                 (string page)
                     // Replace parentheses with unicode ones for nicer display in VS test explorer
                     .Replace("(", "❨")
                     .Replace(")", "❩")))
 
     [<Test; TestCaseSource("links"); NonParallelizable>]
-    let ``Click link``(linkCls, page: App.Routing.Page) =
-        let url = page.ExpectedUrl
+    let ``Click link``(linkCls: string, url: string, page: App.Routing.Page) =
         elt.ByClass("link-" + linkCls).Click()
         let resCls = App.Routing.pageClass page
         let res =
@@ -36,9 +35,8 @@ module Routing =
         Assert.AreEqual(WebFixture.Url + url, WebFixture.Driver.Url)
 
     [<Test; TestCaseSource("links"); NonParallelizable>]
-    let ``Set by model``(linkCls, page: App.Routing.Page) =
+    let ``Set by model``(linkCls: string, url: string, page: App.Routing.Page) =
         Thread.Sleep(500) // Some cases fail without this, mainly ones with empty strings. TODO: investigate
-        let url = page.ExpectedUrl
         elt.ByClass("btn-" + linkCls).Click()
         let resCls = App.Routing.pageClass page
         let res =

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -16,7 +16,12 @@ module Routing =
 
     let links =
         App.Routing.links
-        |> List.map TestCaseData
+        |> List.map (fun (cls, page) ->
+            TestCaseData(cls, page).SetArgDisplayNames(
+                (string page)
+                    // Replace parentheses with unicode ones for nicer display in VS test explorer
+                    .Replace("(", "❨")
+                    .Replace(")", "❩")))
 
     [<Test; TestCaseSource("links"); NonParallelizable>]
     let ``Click link``(linkCls, page: App.Routing.Page) =

--- a/tests/Unit/Web/App.Routing.fs
+++ b/tests/Unit/Web/App.Routing.fs
@@ -108,7 +108,7 @@ let router =
         eprintfn "ROUTER ERROR: %A" e
         reraise()
 
-let matchInnerPage = function
+let innerPageClass = function
     | InnerHome -> "home"
     | InnerNoArg -> "noarg"
     | InnerWithArg x -> sprintf "witharg-%s" x
@@ -119,11 +119,11 @@ let rec pageClass = function
     | NoArg -> "noarg"
     | WithArg x -> sprintf "witharg-%s" x
     | WithArgs(x, y) -> sprintf "withargs-%s-%i" x y
-    | WithUnion u -> "withunion-" + matchInnerPage u
-    | WithUnionNotTerminal(u, s) -> sprintf "withunion2-%s-%s" (matchInnerPage u) s
+    | WithUnion u -> "withunion-" + innerPageClass u
+    | WithUnionNotTerminal(u, s) -> sprintf "withunion2-%s-%s" (innerPageClass u) s
     | WithNestedUnion u -> sprintf "withnested-%s" (pageClass u)
     | WithTuple(x, y, z) -> sprintf "withtuple-%i-%s-%b" x y z
-    | WithRecord { x = x; y = y; z = z } -> sprintf "withrecord-%i-%s-%b" x (matchInnerPage y) z
+    | WithRecord { x = x; y = y; z = z } -> sprintf "withrecord-%i-%s-%b" x (innerPageClass y) z
     | WithList l -> sprintf "withlist-%s" (String.concat "-" [for i, s in l -> sprintf "%i-%s" i s])
     | WithArray a -> sprintf "witharray-%s" (String.concat "-" [for i, s in a -> sprintf "%i-%s" i s])
     | WithPath s -> sprintf "withpath-%s" s
@@ -131,7 +131,7 @@ let rec pageClass = function
     | WithPathAndSuffix2(s, i) -> sprintf "withpathsuffix2-%s-%i" s i
     | WithPathAndSuffix3 s -> sprintf "withpathsuffix3-%s" s
     | WithPathConstant -> "withpathconstant"
-    | WithPathRecord { x = x; y = y; z = z } -> sprintf "withpathrecord-%i-%s-%b" x (matchInnerPage y) z
+    | WithPathRecord { x = x; y = y; z = z } -> sprintf "withpathrecord-%i-%s-%b" x (innerPageClass y) z
 
 let innerlinks =
     [

--- a/tests/Unit/Web/App.Routing.fs
+++ b/tests/Unit/Web/App.Routing.fs
@@ -37,23 +37,21 @@ type Page =
     | [<EndPoint "/with-list">] WithList of list<int * string>
     | [<EndPoint "/with-array">] WithArray of (int * string)[]
 
-    member this.ExpectedUrl'(isInitial: bool) =
+    member this.ExpectedUrl =
         match this with
-        | Home -> if isInitial then "/" else ""
+        | Home -> "/"
         | NoArg -> "/no-arg"
         | WithArg s -> sprintf "/with-arg/%s" s
         | WithArgs(s, i) -> sprintf "/with-args/%s/%i" s i
         | WithUnion u -> sprintf "/with-union%s" u.ExpectedUrl
         | WithUnionNotTerminal(u, s) -> sprintf "/with-union2%s/%s" u.ExpectedUrl s
-        | WithNestedUnion u -> sprintf "/with-nested-union%s" (u.ExpectedUrl' false)
+        | WithNestedUnion u -> sprintf "/with-nested-union%s" u.ExpectedUrl
         | WithTuple((i, s, b)) -> sprintf "/with-tuple/%i/%s/%b" i s b
         | WithRecord { x = x; y = y; z = z } -> sprintf "/with-record/%i%s/%b" x y.ExpectedUrl z
         | WithList l -> sprintf "/with-list/%i%s" l.Length
                         <| String.concat "" [for i, s in l -> sprintf "/%i/%s" i s]
         | WithArray a -> sprintf "/with-array/%i%s" a.Length
                         <| String.concat "" [for i, s in a -> sprintf "/%i/%s" i s]
-
-    member this.ExpectedUrl = this.ExpectedUrl'(true)
 
 and InnerPage =
     | [<EndPoint "/">] InnerHome
@@ -63,7 +61,7 @@ and InnerPage =
 
     member this.ExpectedUrl =
         match this with
-        | InnerHome -> ""
+        | InnerHome -> "/"
         | InnerNoArg -> "/no-arg"
         | InnerWithArg s -> sprintf "/with-arg/%s" s
         | InnerWithArgs(s, i) -> sprintf "/with-args/%s/%i" s i

--- a/tests/Unit/Web/App.Routing.fs
+++ b/tests/Unit/Web/App.Routing.fs
@@ -46,43 +46,11 @@ type Page =
     | [<EndPoint "/with-rest-list/{*rest}">] WithRestList of rest: list<int>
     | [<EndPoint "/with-rest-array/{*rest}">] WithRestArray of rest: (int * string)[]
 
-    member this.ExpectedUrl =
-        match this with
-        | Home -> "/"
-        | NoArg -> "/no-arg"
-        | WithArg s -> sprintf "/with-arg/%s" s
-        | WithArgs(s, i) -> sprintf "/with-args/%s/%i" s i
-        | WithUnion u -> sprintf "/with-union%s" u.ExpectedUrl
-        | WithUnionNotTerminal(u, s) -> sprintf "/with-union2%s/%s" u.ExpectedUrl s
-        | WithNestedUnion u -> sprintf "/with-nested-union%s" u.ExpectedUrl
-        | WithTuple((i, s, b)) -> sprintf "/with-tuple/%i/%s/%b" i s b
-        | WithRecord { x = x; y = y; z = z } -> sprintf "/with-record/%i%s/%b" x y.ExpectedUrl z
-        | WithList l -> sprintf "/with-list/%i%s" l.Length
-                        <| String.concat "" [for i, s in l -> sprintf "/%i/%s" i s]
-        | WithArray a -> sprintf "/with-array/%i%s" a.Length
-                        <| String.concat "" [for i, s in a -> sprintf "/%i/%s" i s]
-        | WithPath s -> sprintf "/with-path/%s" s
-        | WithPathAndSuffix s -> sprintf "/with-path/%s/and-suffix" s
-        | WithPathAndSuffix2(s, i) -> sprintf "/with-path/%s/and-suffix/%i" s i
-        | WithPathAndSuffix3 s -> sprintf "/with-path/%s/other-suffix" s
-        | WithPathConstant -> "/with-path/and/constant"
-        | WithPathRecord { x = x; y = y; z = z } -> sprintf "/with-path-record/%i%s/%b" x y.ExpectedUrl z
-        | WithRestString s -> sprintf "/with-rest-string/%s" s
-        | WithRestList l -> sprintf "/with-rest-list/%s" (l |> Seq.map string |> String.concat "/")
-        | WithRestArray a -> sprintf "/with-rest-list/%s" (a |> Seq.map (fun (i, s) -> sprintf "%i/%s" i s) |> String.concat "/")
-
 and InnerPage =
     | [<EndPoint "/">] InnerHome
     | [<EndPoint "/no-arg">] InnerNoArg
     | [<EndPoint "/with-arg">] InnerWithArg of string
     | [<EndPoint "/with-args">] InnerWithArgs of string * int
-
-    member this.ExpectedUrl =
-        match this with
-        | InnerHome -> "/"
-        | InnerNoArg -> "/no-arg"
-        | InnerWithArg s -> sprintf "/with-arg/%s" s
-        | InnerWithArgs(s, i) -> sprintf "/with-args/%s/%i" s i
 
 and Record =
     {


### PR DESCRIPTION
Includes `{*parameter}` syntax to match the rest of the path.

To do:

* [x] Check that `{*parameter}` is the last fragment in the path spec.
* [x] Add tests for invalid path specs