### PR TITLE
SetState should defer to ShouldRender

### DIFF
--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -69,6 +69,9 @@ type ElmishComponent<'model, 'msg>() =
     /// The Elmish view function.
     abstract View : 'model -> Dispatch<'msg> -> Node    
 
+    override this.ShouldRender() =
+       this.ShouldRender(oldModel, this.Model)
+
     override this.Render() =
         oldModel <- this.Model
         this.View this.Model this.Dispatch
@@ -114,7 +117,7 @@ type ProgramComponent<'model, 'msg>() =
         this.NavigationManager.ToBaseRelativePath(uri)
 
     member internal this.SetState(program, model, dispatch) =
-        if this.ShouldRender() then
+        if this.ShouldRender(oldModel, model) then
             this.ForceSetState(program, model, dispatch)
 
     member internal this.StateHasChanged() =

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -117,7 +117,7 @@ type ProgramComponent<'model, 'msg>() =
         this.NavigationManager.ToBaseRelativePath(uri)
 
     member internal this.SetState(program, model, dispatch) =
-        if not <| obj.ReferenceEquals(model, oldModel) then
+        if this.ShouldRender() then
             this.ForceSetState(program, model, dispatch)
 
     member internal this.StateHasChanged() =

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -36,12 +36,6 @@ type Component() =
 
     let matchCache = Dictionary()
 
-    /// Compare the old model with the new to decide whether this component
-    /// needs to be re-rendered.
-    abstract ShouldRender : oldModel: 'model * newModel: 'model -> bool
-    default this.ShouldRender(oldModel, newModel) =
-        not <| obj.ReferenceEquals(oldModel, newModel)
-
     override this.BuildRenderTree(builder) =
         base.BuildRenderTree(builder)
         this.Render()
@@ -50,10 +44,20 @@ type Component() =
     /// The rendered contents of the component.
     abstract Render : unit -> Node
 
+[<AbstractClass>]
+type Component<'model>() =
+    inherit Component()
+
+    /// Compare the old model with the new to decide whether this component
+    /// needs to be re-rendered.
+    abstract ShouldRender : oldModel: 'model * newModel: 'model -> bool
+    default this.ShouldRender(oldModel, newModel) =
+        not <| obj.ReferenceEquals(oldModel, newModel)
+
 /// A component that is part of an Elmish view.
 [<AbstractClass>]
 type ElmishComponent<'model, 'msg>() =
-    inherit Component()
+    inherit Component<'model>()
 
     let mutable oldModel = Unchecked.defaultof<'model>
 
@@ -82,7 +86,7 @@ type IProgramComponent =
 /// A component that runs an Elmish program.
 [<AbstractClass>]
 type ProgramComponent<'model, 'msg>() =
-    inherit Component()
+    inherit Component<'model>()
 
     let mutable oldModel = Unchecked.defaultof<'model>
     let mutable navigationInterceptionEnabled = false

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -36,6 +36,12 @@ type Component() =
 
     let matchCache = Dictionary()
 
+    /// Compare the old model with the new to decide whether this component
+    /// needs to be re-rendered.
+    abstract ShouldRender : oldModel: 'model * newModel: 'model -> bool
+    default this.ShouldRender(oldModel, newModel) =
+        not <| obj.ReferenceEquals(oldModel, newModel)
+
     override this.BuildRenderTree(builder) =
         base.BuildRenderTree(builder)
         this.Render()
@@ -61,16 +67,7 @@ type ElmishComponent<'model, 'msg>() =
     member val Dispatch = Unchecked.defaultof<Dispatch<'msg>> with get, set
 
     /// The Elmish view function.
-    abstract View : 'model -> Dispatch<'msg> -> Node
-
-    /// Compare the old model with the new to decide whether this component
-    /// needs to be re-rendered.
-    abstract ShouldRender : oldModel: 'model * newModel: 'model -> bool
-    default this.ShouldRender(oldModel, newModel) =
-        not <| obj.ReferenceEquals(oldModel, newModel)
-
-    override this.ShouldRender() =
-       this.ShouldRender(oldModel, this.Model)
+    abstract View : 'model -> Dispatch<'msg> -> Node    
 
     override this.Render() =
         oldModel <- this.Model


### PR DESCRIPTION
Deferring to ShouldRender allows consumers to override the logic that controls whether or not the view is re-rendered, as Reference Equality is not always suitable.