### PR TITLE
[#163] Rename ElementRefBinder to HtmlRef, add Ref<'Component>

### DIFF
--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -221,15 +221,31 @@ and [<AbstractClass>]
             EventHandler<_> this.OnLocationChanged
             |> this.NavigationManager.LocationChanged.RemoveHandler
 
+/// A utility to bind a reference to a rendered component.
+/// See https://fsbolero.io/docs/Blazor#html-element-references
+/// [category: HTML]
+type Ref<'T>() =
+    inherit Ref()
+
+    /// The element or component reference.
+    member val Value = Unchecked.defaultof<'T> with get, set
+
+    override this.Render(builder, sequence) =
+        builder.AddComponentReferenceCapture(sequence, fun v -> this.Value <- unbox<'T> v)
+        sequence + 1
+
 /// A utility to bind a reference to a rendered HTML element.
 /// See https://fsbolero.io/docs/Blazor#html-element-references
 /// [category: HTML]
-type ElementReferenceBinder() =
+type HtmlRef() =
+    inherit Ref<ElementReference>()
 
-    let mutable ref = Unchecked.defaultof<ElementReference>
+    override this.Render(builder, sequence) =
+        builder.AddElementReferenceCapture(sequence, fun v -> this.Value <- v)
+        sequence + 1
 
-    /// The element reference.
-    /// This object must be bound using `Bolero.Html.attr.bindRef` before using this property.
-    member _.Ref = ref
-
-    member internal _.SetRef(r) = ref <- r
+/// A utility to bind a reference to a rendered HTML element.
+/// See https://fsbolero.io/docs/Blazor#html-element-references
+/// [category: HTML]
+[<Obsolete "Use HtmlRef.">]
+type ElementReferenceBinder = HtmlRef

--- a/src/Bolero/Html.fs
+++ b/src/Bolero/Html.fs
@@ -802,13 +802,14 @@ module attr =
     let inline classes (classes: list<string>) : Attr =
         Attr.Classes classes
 
-    /// Bind an element reference.
-    let inline ref (f: ElementReference -> unit) =
-        Attr.Ref (Action<ElementReference>(f))
+    /// Bind an element or component reference.
+    let inline ref (r: Ref<'T>) =
+        Attr.Ref r
 
     /// Bind an element reference.
-    let bindRef (refBinder: ElementReferenceBinder) =
-        ref refBinder.SetRef
+    [<Obsolete "Use attr.ref.">]
+    let inline bindRef (r: Ref<'T>) =
+        Attr.Ref r
 
     let key (k: obj) =
         Attr.Key k

--- a/src/Bolero/Node.fs
+++ b/src/Bolero/Node.fs
@@ -40,7 +40,7 @@ type Attr =
     /// [omit]
     | FragmentAttr of string * ((Rendering.RenderTreeBuilder -> Node -> unit) -> obj)
     /// [omit]
-    | Ref of Action<ElementReference>
+    | Ref of Ref
 
 /// HTML fragment.
 /// [category: HTML]
@@ -69,3 +69,7 @@ and Node =
     /// A single Blazor component, statically typed.
     static member BlazorComponent<'T when 'T :> IComponent>(attrs, children) =
         Node.Component(typeof<'T>, attrs, children)
+
+and [<AbstractClass>] Ref() =
+    /// [omit]
+    abstract Render : Rendering.RenderTreeBuilder * int -> int

--- a/src/Bolero/Render.fs
+++ b/src/Bolero/Render.fs
@@ -200,9 +200,7 @@ and renderAttrs currentComp (builder: RenderTreeBuilder) matchCache sequence att
     | ValueSome k -> builder.SetKey(k)
     match ref with
     | ValueNone -> sequence
-    | ValueSome r ->
-        builder.AddElementReferenceCapture(sequence, r)
-        sequence + 1
+    | ValueSome r -> r.Render(builder, sequence)
 
 let RenderNode currentComp builder (matchCache: Dictionary<Type, _>) node =
     let getMatchParams (ty: Type) =

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -137,16 +137,16 @@ type SecretPw = Template<"""<div>
                                 <input type="number" bind="${Value}" />
                             </div>""">
 
-let btnRef = ElementReferenceBinder()
+let btnRef = HtmlRef()
 
 let viewForm (js: IJSRuntime) model dispatch =
     div [] [
         input [attr.value model.input; on.change (fun e -> dispatch (SetInput (unbox e.Value)))]
         input [
-            attr.bindRef btnRef
+            attr.ref btnRef
             attr.``type`` "submit"
             on.click (fun _ ->
-                js.InvokeAsync("console.log", btnRef.Ref) |> ignore
+                js.InvokeAsync("console.log", btnRef.Value) |> ignore
                 dispatch Submit
             )
             attr.style (if model.input = "" then "color:gray;" else null)

--- a/tests/Unit.Client/Html.fs
+++ b/tests/Unit.Client/Html.fs
@@ -145,28 +145,32 @@ type Binds() =
 type BindElementRef() =
     inherit Component()
 
-    let mutable elt1 = Unchecked.defaultof<ElementReference>
-    let elt2 = ElementReferenceBinder()
+    let elt = HtmlRef()
 
     [<Inject>]
     member val JSRuntime = Unchecked.defaultof<IJSRuntime> with get, set
 
     override this.Render() =
+        button [
+            attr.``class`` "element-ref"
+            attr.ref elt
+            on.task.event "click" (fun _ ->
+                this.JSRuntime.InvokeVoidAsync("setContent", elt.Value, "ElementRef is bound").AsTask())
+        ] [text "Click me"]
+
+type BindComponentRef() =
+    inherit Component()
+
+    let cmp = Ref<NavLink>()
+    let mutable txt = "Click me"
+
+    override _.Render() =
         concat [
+            navLink NavLinkMatch.All [attr.ref cmp; "ActiveClass" => "component-ref-is-bound"] []
             button [
-                attr.``class`` "element-ref"
-                attr.ref (fun r -> elt1 <- r)
-                on.task.event "click" (fun _ ->
-                    this.JSRuntime.InvokeVoidAsync("setContent", elt1, "ElementRef 1 is bound").AsTask()
-                )
-            ] [text "Click me"]
-            button [
-                attr.``class`` "element-ref-binder"
-                attr.bindRef elt2
-                on.async.event "click" (fun _ -> async {
-                    do! this.JSRuntime.InvokeAsync("setContent", elt2.Ref, "ElementRef 2 is bound").AsTask() |> Async.AwaitTask
-                })
-            ] [text "Click me"]
+                attr.``class`` "component-ref"
+                on.event "click" (fun _ -> txt <- cmp.Value.ActiveClass)
+            ] [text txt]
         ]
 
 let Tests() =
@@ -194,4 +198,5 @@ let Tests() =
         comp<BoleroComponent> ["Ident" => "bolero-component"] []
         comp<Binds> [] []
         comp<BindElementRef> [] []
+        comp<BindComponentRef> [] []
     ]

--- a/tests/Unit/Tests/Html.fs
+++ b/tests/Unit/Tests/Html.fs
@@ -183,9 +183,11 @@ module Html =
         let btn = elt.ByClass("element-ref")
         testNotNull <@ btn @>
         btn.Click()
-        elt.Eventually <@ btn.Text = "ElementRef 1 is bound" @>
+        elt.Eventually <@ btn.Text = "ElementRef is bound" @>
 
-        let btn = elt.ByClass("element-ref-binder")
+    [<Test>]
+    let ComponentRefBinder() =
+        let btn = elt.ByClass("component-ref")
         testNotNull <@ btn @>
         btn.Click()
-        elt.Eventually <@ btn.Text = "ElementRef 2 is bound" @>
+        elt.Eventually <@ btn.Text = "component-ref-is-bound" @>


### PR DESCRIPTION
* More sensible names for binding HTML elements:

    * `ElementRefBinder` renamed to `HtmlRef` (old name still available but obsolete)
    * `attr.bindRef` renamed to `attr.ref` (old name still available but obsolete)
    * `attr.ref` taking a function removed
    * `ref.Ref` renamed to `ref.Value`

    ```fsharp
    let theDiv = HtmlRef()    // Used to be: let theDiv = ElementRefBinder()

    div [
        attr.ref theDiv    // Used to be: attr.bindRef theDiv
        on.click (fun _ -> doSomethingWith theDiv.Value)    // Used to be: doSomethingWith theDiv.Ref
    ] []
    ```

* Added `Ref<'Component>` which provides the same capability for Blazor components, using the same `attr.ref`:

    ```fsharp
    let theComp = Ref<MyComponent>()

    comp<MyComponent> [
        attr.ref theComp
        on.click (fun _ -> doSomethingWith theComp.Value)
    ] []
    ```