### PR TITLE
Change ShouldRender to invoke override instead of base implementation

### DIFF
--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -84,7 +84,7 @@ type ElmishComponent<'model, 'msg>() =
     abstract View : 'model -> Dispatch<'msg> -> Node
 
     override this.ShouldRender() =
-        base.ShouldRender(this.OldModel, this.Model)
+        this.ShouldRender(this.OldModel, this.Model)
 
     override this.Render() =
         this.OldModel <- this.Model


### PR DESCRIPTION
Hi, 

This PR addresses a bug in ElmishComponent where an override of ShouldRender('t, 't) is not invoked, instead the default implementation is always invoked.

