### PR TITLE
Do not render Ref until after Child Content

### DIFF
--- a/tests/Unit.Client/Html.fs
+++ b/tests/Unit.Client/Html.fs
@@ -166,7 +166,8 @@ type BindComponentRef() =
 
     override _.Render() =
         concat [
-            navLink NavLinkMatch.All [attr.ref cmp; "ActiveClass" => "component-ref-is-bound"] []
+            navLink NavLinkMatch.All [attr.ref cmp; "ActiveClass" => "component-ref-is-bound"; attr.``class`` "nav-link" ] [
+                 text "Home" ]
             button [
                 attr.``class`` "component-ref"
                 on.event "click" (fun _ -> txt <- cmp.Value.ActiveClass)

--- a/tests/Unit/Tests/Html.fs
+++ b/tests/Unit/Tests/Html.fs
@@ -191,3 +191,8 @@ module Html =
         testNotNull <@ btn @>
         btn.Click()
         elt.Eventually <@ btn.Text = "component-ref-is-bound" @>
+
+    [<Test>]
+    let ComponentRefBinderRendersChildren() =
+        let nav = elt.ByClass("nav-link")
+        test <@ nav.Text = "Home" @>


### PR DESCRIPTION
ComponentReferences should be rendered after any child content. For example, the Razor code

```
 <NavLink Match="NavLinkMatch.All"  @ref="myComponent" href="Form"  >
    "Form"
</NavLink>
```
Will be compiled to 

```
__builder.AddAttribute(2, "href", "Form");
            __builder.AddAttribute(3, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
                __builder2.AddMarkupContent(4, "\r\n    \"Form\"\r\n");
            }
            ));
            __builder.AddComponentReferenceCapture(5, (__value) => {
#nullable restore
#line 1 "C:\Users\doug.quiddington\source\repos\BlazorApp\Shared\NavMenu.razor"
                                          myComponent = (Microsoft.AspNetCore.Components.Routing.NavLink)__value;

#line default
#line hidden
#nullable disable
            }
            );
            __builder.CloseComponent();
```

Currently, Bolero renders the ComponentReference before any child content, which results in an exception. This PR puts the ComponentReference after Child Content