### PR TITLE
Fix #166: don't run Elmish subscriptions and init commands during prerender

### DIFF
--- a/src/Bolero/Bolero.fsproj
+++ b/src/Bolero/Bolero.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="TemplatingInternals.fs" />
     <Compile Include="Render.fs" />
     <Compile Include="Router.fs" />
+    <Compile Include="ProgramRun.fs" />
     <Compile Include="Components.fs" />
     <Compile Include="Remoting.fs" />
     <Compile Include="Remoting.Client.fs" />

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -118,7 +118,6 @@ and [<AbstractClass>]
     let mutable runProgramLoop = fun () -> ()
     let mutable dispatch = ignore<'msg>
     let mutable router = None : option<IRouter<'model, 'msg>>
-    let mutable update = fun _ x -> x, Cmd.none
     let mutable setState = fun program model dispatch ->
         view <- Program.view program model dispatch
         oldModel <- model
@@ -191,8 +190,7 @@ and [<AbstractClass>]
                 (fun init arg ->
                     let model, cmd = init arg
                     model, setDispatch :: cmd)
-                (fun u -> update <- u; u)
-                id
+                id id
                 (fun _ model dispatch -> setState program model dispatch)
                 id
         runProgramLoop <- Program'.runFirstRender this program

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -115,8 +115,13 @@ and [<AbstractClass>]
 
     let mutable oldModel = Unchecked.defaultof<'model>
     let mutable view = Node.Empty
+    let mutable runProgramLoop = fun () -> ()
     let mutable dispatch = ignore<'msg>
     let mutable router = None : option<IRouter<'model, 'msg>>
+    let mutable update = fun _ x -> x, Cmd.none
+    let mutable setState = fun program model dispatch ->
+        view <- Program.view program model dispatch
+        oldModel <- model
 
     /// [omit]
     [<Inject>]
@@ -160,10 +165,6 @@ and [<AbstractClass>]
         let uri = this.NavigationManager.Uri
         this.NavigationManager.ToBaseRelativePath(uri)
 
-    member internal this.SetState(program, model, dispatch) =
-        if this.ShouldRender(oldModel, model) then
-            this.ForceSetState(program, model, dispatch)
-
     member internal _.StateHasChanged() =
         base.StateHasChanged()
 
@@ -179,27 +180,25 @@ and [<AbstractClass>]
                 with _ -> () // fails if run in prerender
         )
 
-    member this.Rerender() =
-        this.ForceSetState(this.Program, oldModel, dispatch)
-
-    member internal _._OnInitialized() =
-        base.OnInitialized()
-
     override this.OnInitialized() =
-        this._OnInitialized()
-        let program = this.Program
+        base.OnInitialized()
         let setDispatch d =
             dispatch <- d
-        program
-        |> Program.map
-            (fun init arg ->
-                let model, cmd = init arg
-                model, setDispatch :: cmd)
-            id id
-            (fun _ model dispatch ->
-                this.SetState(program, model, dispatch))
-            id
-        |> Program.runWith this
+        let mutable program = this.Program
+        program <-
+            program
+            |> Program.map
+                (fun init arg ->
+                    let model, cmd = init arg
+                    model, setDispatch :: cmd)
+                (fun u -> update <- u; u)
+                id
+                (fun _ model dispatch -> setState program model dispatch)
+                id
+        runProgramLoop <- Program'.runFirstRender this program
+        setState <- fun program model dispatch ->
+            if this.ShouldRender(oldModel, model) then
+                this.ForceSetState(program, model, dispatch)
 
     member internal this.InitRouter
         (
@@ -217,8 +216,12 @@ and [<AbstractClass>]
             initModel, []
 
     override this.OnAfterRenderAsync(firstRender) =
-        if router.IsSome && firstRender then
-            this.NavigationInterception.EnableNavigationInterceptionAsync()
+        if firstRender then
+            runProgramLoop()
+            if router.IsSome then
+                this.NavigationInterception.EnableNavigationInterceptionAsync()
+            else
+                Task.CompletedTask
         else
             Task.CompletedTask
 

--- a/src/Bolero/Program.fs
+++ b/src/Bolero/Program.fs
@@ -22,21 +22,21 @@
 /// [category: Routing]
 module Bolero.Program
 
+open System.Reflection
 open Elmish
 
 /// Attach `router` to `program` when it is run as the `Program` of a `ProgramComponent`.
 let withRouter
         (router: IRouter<'model, 'msg>)
         (program: Program<'model, 'msg>) =
-    let mutable update = Unchecked.defaultof<_>
     program
     |> Program.map
         (fun init comp ->
             let model, initCmd = init comp
+            let update = typeof<Program<'model, 'msg>>.GetProperty("update", BindingFlags.NonPublic ||| BindingFlags.Instance).GetValue(program) :?> _
             let model, compCmd = comp.InitRouter(router, update, model)
             model, initCmd @ compCmd)
-        (fun u -> update <- u; u)
-        id id id
+        id id id id
 
 /// Attach a router inferred from `makeMessage` and `getEndPoint` to `program`
 /// when it is run as the `Program` of a `ProgramComponent`.

--- a/src/Bolero/ProgramRun.fs
+++ b/src/Bolero/ProgramRun.fs
@@ -1,0 +1,105 @@
+﻿// Due to this issue, we need to reimplement a variant of Program.runWith:
+// https://github.com/elmish/elmish/issues/210
+// As soon as the above issue is solved, this file can go.
+namespace Elmish
+open System
+
+[<Struct>]
+type internal RingState<'item> =
+    | Writable of wx:'item array * ix:int
+    | ReadWritable of rw:'item array * wix:int * rix:int
+
+type internal RingBuffer<'item>(size) =
+    let doubleSize ix (items: 'item array) =
+        seq { yield! items |> Seq.skip ix
+              yield! items |> Seq.take ix
+              for _ in 0..items.Length do
+                yield Unchecked.defaultof<'item> }
+        |> Array.ofSeq
+
+    let mutable state : 'item RingState =
+        Writable (Array.zeroCreate (max size 10), 0)
+
+    member __.Pop() =
+        match state with
+        | ReadWritable (items, wix, rix) ->
+            let rix' = (rix + 1) % items.Length
+            match rix' = wix with
+            | true ->
+                state <- Writable(items, wix)
+            | _ ->
+                state <- ReadWritable(items, wix, rix')
+            Some items.[rix]
+        | _ ->
+            None
+
+    member __.Push (item:'item) =
+        match state with
+        | Writable (items, ix) ->
+            items.[ix] <- item
+            let wix = (ix + 1) % items.Length
+            state <- ReadWritable(items, wix, ix)
+        | ReadWritable (items, wix, rix) ->
+            items.[wix] <- item
+            let wix' = (wix + 1) % items.Length
+            match wix' = rix with
+            | true ->
+                state <- ReadWritable(items |> doubleSize rix, items.Length, 0)
+            | _ ->
+                state <- ReadWritable(items, wix', rix)
+
+// In this module we split Elmish's Program.runWith into two parts:
+// 1. The first rendering, which must be done in OnInitialized()
+// 2. The execution of init cmd and subscriptions, which must be done in OnAfterRenderAsync(true)
+module internal Program' =
+
+    module Cmd =
+        let internal exec onError (dispatch: Dispatch<'msg>) (cmd: Cmd<'msg>) =
+            cmd |> List.iter (fun call -> try call dispatch with ex -> onError ex)
+
+    let runFirstRender (arg: 'arg) (program: Program<'arg, 'model, 'msg, 'view>) =
+        // An ugly way to extract init and update because they're private
+        let mutable init = Unchecked.defaultof<_>
+        let mutable update = Unchecked.defaultof<_>
+        let mutable subscribe = Unchecked.defaultof<_>
+        let program =
+            program
+            |> Program.map
+                (fun i -> init <- i; i)
+                (fun u -> update <- u; u)
+                id
+                id
+                (fun s -> subscribe <- s; s)
+
+        let (model,cmd) = init arg
+        let rb = RingBuffer 10
+        let mutable reentered = false
+        let mutable state = model
+        let rec dispatch msg =
+            if reentered then
+                rb.Push msg
+            else
+                reentered <- true
+                let mutable nextMsg = Some msg
+                while Option.isSome nextMsg do
+                    let msg = nextMsg.Value
+                    try
+                        let (model',cmd') = update msg state
+                        Program.setState program model' dispatch
+                        cmd' |> Cmd.exec (fun ex -> Program.onError program (sprintf "Error in command while handling: %A" msg, ex)) dispatch
+                        state <- model'
+                    with ex ->
+                        Program.onError program (sprintf "Unable to process the message: %A" msg, ex)
+                    nextMsg <- rb.Pop()
+                reentered <- false
+
+        Program.setState program model dispatch
+        fun () ->
+            let sub =
+                try
+                    subscribe model
+                with ex ->
+                    Program.onError program ("Unable to subscribe:", ex)
+                    Cmd.none
+            Cmd.batch [sub; cmd]
+            |> Cmd.exec (fun ex -> Program.onError program ("Error initializing:", ex)) dispatch

--- a/tests/Remoting.Client/Main.fs
+++ b/tests/Remoting.Client/Main.fs
@@ -20,7 +20,6 @@
 
 module Bolero.Tests.Remoting.Client
 
-open System
 open System.Collections.Generic
 open Microsoft.AspNetCore.Components.Authorization
 open Bolero


### PR DESCRIPTION
This moves running the Elmish subscriptions and init commands from `OnInitialized` to `OnAfterRenderAsync`.

It reimplements of bits of Elmish because of elmish/elmish#210.