### PR TITLE
fix: output attributes in original case

### DIFF
--- a/src/Bolero.Templating.Provider/Parsing.fs
+++ b/src/Bolero.Templating.Provider/Parsing.fs
@@ -372,6 +372,7 @@ let ParseDoc (filename: option<string>) (doc: HtmlDocument) : ParsedTemplates =
 /// Get the HTML document for the given type provider argument, either inline or from a file.
 let GetDoc (fileOrContent: string) (rootFolder: string) : option<string> * HtmlDocument =
     let doc = HtmlDocument()
+    doc.OptionOutputOriginalCase <- true
     if fileOrContent.Contains("<") then
         doc.LoadHtml(fileOrContent)
         None, doc


### PR DESCRIPTION
Addresses #256.

Output templates' element attributes in original case.

Currently, `Template<>` types generate incorrect output when sources contain `svg` elements using the _case-sensitive_ `viewBox` attribute, used to enable resizing. They are rendered incorrectly because the output attribute is converted to `viewbox` (all lower case). The `viewbox` (lowercase) attribute is ignored by browser renderers.

See linked issue for further details.