### PR TITLE
Support invalidation on template file changes

### DIFF
--- a/src/Bolero.Templating.Provider/CodeGen.fs
+++ b/src/Bolero.Templating.Provider/CodeGen.fs
@@ -22,6 +22,7 @@ module Bolero.Templating.CodeGen
 
 open System
 open System.Reflection
+open Bolero.Templating.Parsing
 open FSharp.Quotations
 open Microsoft.AspNetCore.Components
 open ProviderImplementation.ProvidedTypes
@@ -142,8 +143,7 @@ let PopulateOne (filename: option<string>) (subTemp: option<string>) (ty: Provid
     ]
 
 /// Populate the members of the provided type for a root template and its nested templates.
-let Populate (mainTy: ProvidedTypeDefinition) (pathOrHtml: string) (rootFolder: string) =
-    let content = Parsing.ParseFileOrContent pathOrHtml rootFolder
+let Populate (mainTy: ProvidedTypeDefinition) (content: ParsedTemplates) =
     let filename = content.Filename
     PopulateOne filename None mainTy content.Main
     for KeyValue(name, content) in content.Nested do

--- a/src/Bolero.Templating.Provider/Provider.fs
+++ b/src/Bolero.Templating.Provider/Provider.fs
@@ -20,6 +20,8 @@
 
 namespace Bolero.Templating
 
+open System.Collections.Concurrent
+open System.IO
 open System.Reflection
 open FSharp.Core.CompilerServices
 open ProviderImplementation.ProvidedTypes
@@ -33,20 +35,49 @@ type Template (cfg: TypeProviderConfig) as this =
 
     let thisAssembly = Assembly.GetExecutingAssembly()
     let rootNamespace = "Bolero"
+    let cache = ConcurrentDictionary<string, ProvidedTypeDefinition * FileSystemWatcher option>()
+
+    let watchFileChanges key fileName =
+        let fullPath = Path.Combine(cfg.ResolutionFolder, fileName) |> Path.Canonicalize
+        let fileWatcher = new FileSystemWatcher(
+            Path = Path.GetDirectoryName(fullPath),
+            Filter = Path.GetFileName(fullPath)
+        )
+
+        let lockObj = obj()
+        let mutable disposed = false
+
+        let changeHandler = fun _ ->
+            lock lockObj (fun _ ->
+                if disposed then () else
+                cache.TryRemove key |> ignore
+                fileWatcher.Dispose()
+                disposed <- true
+                this.Invalidate())
+
+        fileWatcher.Changed.Add(changeHandler)
+        fileWatcher.Deleted.Add(changeHandler)
+        fileWatcher.EnableRaisingEvents <- true
+        fileWatcher
 
     do try
         let templateTy = ProvidedTypeDefinition(thisAssembly, rootNamespace, "Template", None, isErased = false)
         let sp = ProvidedStaticParameter("pathOrHtml", typeof<string>)
         sp.AddXmlDoc("The path to an HTML file, or an HTML string directly.")
         templateTy.DefineStaticParameters([sp], fun typename pars ->
-            let asm = ProvidedAssembly()
             match pars with
             | [| :? string as pathOrHtml |] ->
-                let ty = ProvidedTypeDefinition(asm, rootNamespace, typename, Some typeof<TemplateNode>,
-                            isErased = false,
-                            hideObjectMethods = true)
-                CodeGen.Populate ty pathOrHtml cfg.ResolutionFolder
-                asm.AddTypes([ty])
+                let ty, _ =
+                    cache.GetOrAdd(pathOrHtml, fun key ->
+                        let asm = ProvidedAssembly()
+                        let ty = ProvidedTypeDefinition(asm, rootNamespace, typename, Some typeof<TemplateNode>,
+                                    isErased = false,
+                                    hideObjectMethods = true)
+                        let content = Parsing.ParseFileOrContent pathOrHtml cfg.ResolutionFolder
+                        CodeGen.Populate ty content
+                        asm.AddTypes([ty])
+                        let fileWatcher = content.Filename |> Option.map (watchFileChanges key)
+                        ty, fileWatcher)
                 ty
             | x -> failwith $"Unexpected parameter values: {x}"
         )


### PR DESCRIPTION
Type providers have an invalidation mechanism that allows type provider to notify the IDE of a change in the schema of generated types; it also allows type provider to not generate types on every change in a source code file.

This PR adds caching of generated types and tracking changes in template files for invalidation purposes.

![JetBrains1](https://user-images.githubusercontent.com/26364714/185802401-6921c9eb-121c-4144-8e7e-0861768ebbca.gif)
