### PR TITLE
Use a manual renderer to fix prerendering

### DIFF
--- a/src/Bolero.Server/Components.fs
+++ b/src/Bolero.Server/Components.fs
@@ -150,14 +150,10 @@ module Rendering =
                         |> render renderComp (frames.Slice(frame.ComponentSubtreeLength)) Normal
                     | _ ->
                         failwith "Invalid use of rootComp"
-                elif frame.ComponentType = typeof<BoleroScript> then
-                    if frame.ComponentSubtreeLength <> 1 then
-                        failwith "Invalid use of boleroScript"
-                    renderComp.RenderComponent(typeof<BoleroScript>, sb, null, true)
-                    |> render renderComp (frames.Slice(1)) Normal
                 else
                     let attributes = getComponentAttributes (frames.Slice(1, frame.ComponentSubtreeLength - 1))
-                    renderComp.RenderComponent(frame.ComponentType, sb, attributes, false)
+                    let forceStatic = frame.ComponentType = typeof<BoleroScript>
+                    renderComp.RenderComponent(frame.ComponentType, sb, attributes, forceStatic)
                     |> render renderComp (frames.Slice(frame.ComponentSubtreeLength)) Normal
             | RenderTreeFrameType.ComponentReferenceCapture
             | RenderTreeFrameType.ElementReferenceCapture

--- a/src/Bolero.Server/Components.fs
+++ b/src/Bolero.Server/Components.fs
@@ -20,49 +20,23 @@
 
 namespace Bolero.Server.Components
 
+#nowarn "3391"
+
 open System
+open System.Collections.Generic
 open System.IO
+open System.Text
 open System.Text.Encodings.Web
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Components
+open Microsoft.AspNetCore.Components.RenderTree
+open Microsoft.AspNetCore.Components.Rendering
 open Microsoft.AspNetCore.Html
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Mvc.Rendering
 open Microsoft.AspNetCore.Mvc.ViewFeatures
 open Bolero
 open Bolero.Server
-
-module internal Impl =
-
-    let private emptyContent = Task.FromResult { new IHtmlContent with member _.WriteTo(_, _) = () }
-
-    let renderComponentAsync (html: IHtmlHelper) (componentType: Type) (config: IBoleroHostConfig) (parameters: obj) =
-        match config.IsServer, config.IsPrerendered with
-        | true,  true  -> html.RenderComponentAsync(componentType, RenderMode.ServerPrerendered, parameters)
-        | true,  false -> html.RenderComponentAsync(componentType, RenderMode.Server, parameters)
-        | false, true  -> html.RenderComponentAsync(componentType, RenderMode.Static, parameters)
-        | false, false -> emptyContent
-
-    type [<Struct>] RenderType =
-        | FromConfig of IBoleroHostConfig
-        | Page
-
-    let renderComp
-            (componentType: Type)
-            (httpContext: HttpContext)
-            (htmlHelper: IHtmlHelper)
-            (renderType: RenderType)
-            (parameters: obj)
-            = task {
-        (htmlHelper :?> IViewContextAware).Contextualize(ViewContext(HttpContext = httpContext))
-        let! htmlContent =
-            match renderType with
-            | FromConfig config -> renderComponentAsync htmlHelper componentType config parameters
-            | Page -> htmlHelper.RenderComponentAsync(componentType, RenderMode.Static, parameters)
-        return using (new StringWriter()) <| fun writer ->
-            htmlContent.WriteTo(writer, HtmlEncoder.Default)
-            writer.ToString()
-    }
 
 type Page() =
     inherit Component()
@@ -78,18 +52,8 @@ type RootComponent() =
     [<Parameter>]
     member val ComponentType = Unchecked.defaultof<Type> with get, set
 
-    [<Inject>]
-    member val HttpContextAccessor = Unchecked.defaultof<IHttpContextAccessor> with get, set
-
-    [<Inject>]
-    member val HtmlHelper = Unchecked.defaultof<IHtmlHelper> with get, set
-
-    [<Inject>]
-    member val BoleroConfig = Unchecked.defaultof<IBoleroHostConfig> with get, set
-
-    override this.BuildRenderTree(builder) =
-        let body = Impl.renderComp this.ComponentType this.HttpContextAccessor.HttpContext this.HtmlHelper (Impl.FromConfig this.BoleroConfig) null
-        builder.AddMarkupContent(0, body.Result)
+    override this.BuildRenderTree(_builder) =
+        failwith "RootComponent cannot be rendered as a Blazor component"
 
 type BoleroScript() =
     inherit ComponentBase()
@@ -99,3 +63,129 @@ type BoleroScript() =
 
     override this.BuildRenderTree(builder) =
         builder.AddMarkupContent(0, BoleroHostConfig.Body(this.Config))
+
+module Rendering =
+
+    let private emptyContent = Task.FromResult { new IHtmlContent with member _.WriteTo(_, _) = () }
+
+    let internal renderComponentAsync (html: IHtmlHelper) (componentType: Type) (config: IBoleroHostConfig) (parameters: obj) =
+        match config.IsServer, config.IsPrerendered with
+        | true,  true  -> html.RenderComponentAsync(componentType, RenderMode.ServerPrerendered, parameters)
+        | true,  false -> html.RenderComponentAsync(componentType, RenderMode.Server, parameters)
+        | false, true  -> html.RenderComponentAsync(componentType, RenderMode.Static, parameters)
+        | false, false -> emptyContent
+
+    type [<Struct>] RenderType =
+        | FromConfig of IBoleroHostConfig
+        | Page
+
+    let private renderCompTo
+            (sb: StringBuilder)
+            (componentType: Type)
+            (httpContext: HttpContext)
+            (htmlHelper: IHtmlHelper)
+            (renderType: RenderType)
+            (parameters: obj)
+            = task {
+        (htmlHelper :?> IViewContextAware).Contextualize(ViewContext(HttpContext = httpContext))
+        let! htmlContent =
+            match renderType with
+            | FromConfig config -> renderComponentAsync htmlHelper componentType config parameters
+            | Page -> htmlHelper.RenderComponentAsync(componentType, RenderMode.Static, parameters)
+        using (new StringWriter(sb)) <| fun writer ->
+            htmlContent.WriteTo(writer, HtmlEncoder.Default)
+    }
+
+    let private selfClosingElements = HashSet [ "area"; "base"; "br"; "col"; "embed"; "hr"; "img"; "input"; "link"; "meta"; "param"; "source"; "track"; "wbr" ]
+
+    type [<Struct>] private RenderState =
+        | Normal
+        | InElement
+
+    type private IRenderComponents =
+        abstract RenderComponent : componentType: Type * stringBuilder: StringBuilder * forceStatic: bool -> StringBuilder
+        abstract RenderBoleroString : unit -> string
+
+    let rec private render (renderComp: IRenderComponents) (frames: ReadOnlySpan<RenderTreeFrame>) (state: RenderState) (sb: StringBuilder) : unit =
+        if not frames.IsEmpty then
+            let frame = &frames[0]
+            match frame.FrameType with
+            | RenderTreeFrameType.Element ->
+                if state = InElement then sb.Append(">") |> ignore
+                sb.Append("<").Append(frame.ElementName)
+                |> render renderComp (frames.Slice(1, frame.ElementSubtreeLength - 1)) InElement
+                if selfClosingElements.Contains(frame.ElementName) then
+                    sb.Append("/>")
+                else
+                    sb.Append("</").Append(frame.ElementName).Append(">")
+                |> render renderComp (frames.Slice(1 + frame.ElementSubtreeLength - 1)) Normal
+            | RenderTreeFrameType.Text ->
+                if state = InElement then sb.Append(">") |> ignore
+                sb.Append(HtmlEncoder.Default.Encode frame.TextContent)
+                |> render renderComp (frames.Slice(1)) Normal
+            | RenderTreeFrameType.Markup ->
+                if state = InElement then sb.Append(">") |> ignore
+                sb.Append(frame.MarkupContent)
+                |> render renderComp (frames.Slice(1)) Normal
+            | RenderTreeFrameType.Region ->
+                render renderComp (frames.Slice(1)) state sb
+            | RenderTreeFrameType.Attribute ->
+                if state <> InElement then failwith "Shouldn't happen: attribute outside of element"
+                sb.Append(" ").Append(frame.AttributeName).Append("=\"")
+                    .Append(HtmlEncoder.Default.Encode (frame.AttributeValue.ToString())).Append("\"")
+                |> render renderComp (frames.Slice(1)) state
+            | RenderTreeFrameType.Component ->
+                if state = InElement then sb.Append(">") |> ignore
+                if frame.ComponentType = typeof<RootComponent> then
+                    if not (frame.ComponentSubtreeLength = 2
+                            && frames[1].FrameType = RenderTreeFrameType.Attribute
+                            && frames[1].AttributeName = "ComponentType") then
+                        failwith "Invalid use of rootComp"
+                    let componentType = frames[1].AttributeValue :?> Type
+                    renderComp.RenderComponent(componentType, sb, false)
+                    |> render renderComp (frames.Slice(2)) Normal
+                elif frame.ComponentType = typeof<BoleroScript> then
+                    if frame.ComponentSubtreeLength <> 1 then
+                        failwith "Invalid use of boleroScript"
+                    renderComp.RenderComponent(typeof<BoleroScript>, sb, true)
+                    |> render renderComp (frames.Slice(1)) Normal
+                else
+                    if frame.ComponentSubtreeLength <> 1 then
+                        failwith "Passing parameters to components not supported yet"
+                    renderComp.RenderComponent(frame.ComponentType, sb, false)
+                    |> render renderComp (frames.Slice(1)) Normal
+            | RenderTreeFrameType.ComponentReferenceCapture
+            | RenderTreeFrameType.ElementReferenceCapture
+            | RenderTreeFrameType.None
+            | _ ->
+                ()
+
+    let private renderWith (renderComp: IRenderComponents) (node: Node) =
+        let matchCache = Node.MakeMatchCache()
+        use renderTreeBuilder = new RenderTreeBuilder()
+        node.Invoke(null, renderTreeBuilder, matchCache, 0) |> ignore
+        let frames = renderTreeBuilder.GetFrames()
+        let sb = StringBuilder()
+        render renderComp (frames.Array.AsSpan(0, frames.Count)) Normal sb
+        sb.ToString()
+
+    let renderPage (page: Node) httpContext htmlHelper boleroConfig =
+        let renderComp =
+            { new IRenderComponents with
+                member _.RenderComponent(ty, sb, forceStatic) =
+                    let renderType = if forceStatic then Page else FromConfig boleroConfig
+                    (renderCompTo sb ty httpContext htmlHelper renderType null)
+                        .GetAwaiter().GetResult()
+                    sb
+                member _.RenderBoleroString() =
+                    BoleroHostConfig.Body(boleroConfig) }
+        renderWith renderComp page
+
+    let renderPlain (node: Node) =
+        let renderComp =
+            { new IRenderComponents with
+                member _.RenderComponent(_, _, _) =
+                    failwith "Components not supported in plain HTML"
+                member _.RenderBoleroString() =
+                    failwith "Components not supported in plain HTML" }
+        renderWith renderComp node

--- a/src/Bolero.Server/Components.fs
+++ b/src/Bolero.Server/Components.fs
@@ -182,6 +182,5 @@ module Rendering =
     let renderPlain (node: Node) =
         let renderComp =
             { new IRenderComponents with
-                member _.RenderComponent(_, _, _, _) =
-                    failwith "Components not supported in plain HTML" }
+                member _.RenderComponent(_, sb, _, _) = sb }
         renderWith renderComp node

--- a/src/Bolero.Server/Components.fs
+++ b/src/Bolero.Server/Components.fs
@@ -96,7 +96,6 @@ module Rendering =
 
     type private IRenderComponents =
         abstract RenderComponent : componentType: Type * stringBuilder: StringBuilder * attributes: IDictionary<string, obj> * forceStatic: bool -> StringBuilder
-        abstract RenderBoleroString : unit -> string
 
     let private emptyAttributes = dict<string, obj> []
 
@@ -177,16 +176,12 @@ module Rendering =
                     let renderType = if forceStatic then Page else FromConfig boleroConfig
                     (renderCompTo sb ty httpContext htmlHelper renderType attributes)
                         .GetAwaiter().GetResult()
-                    sb
-                member _.RenderBoleroString() =
-                    BoleroHostConfig.Body(boleroConfig) }
+                    sb }
         renderWith renderComp page
 
     let renderPlain (node: Node) =
         let renderComp =
             { new IRenderComponents with
                 member _.RenderComponent(_, _, _, _) =
-                    failwith "Components not supported in plain HTML"
-                member _.RenderBoleroString() =
                     failwith "Components not supported in plain HTML" }
         renderWith renderComp node

--- a/src/Bolero.Server/Components.fs
+++ b/src/Bolero.Server/Components.fs
@@ -38,14 +38,6 @@ open Microsoft.AspNetCore.Mvc.ViewFeatures
 open Bolero
 open Bolero.Server
 
-type Page() =
-    inherit Component()
-
-    [<Parameter>]
-    member val Node = Unchecked.defaultof<Node> with get, set
-
-    override this.Render() = this.Node
-
 type RootComponent() =
     inherit ComponentBase()
 

--- a/src/Bolero.Server/Extensions.fs
+++ b/src/Bolero.Server/Extensions.fs
@@ -40,19 +40,21 @@ type ServerComponentsExtensions =
     /// Render a Bolero component in a Razor page.
     [<Extension>]
     static member RenderComponentAsync(html: IHtmlHelper, componentType: Type, config: IBoleroHostConfig, [<Optional; DefaultParameterValue null>] parameters: obj) =
-        Components.Impl.renderComponentAsync html componentType config parameters
+        Components.Rendering.renderComponentAsync html componentType config parameters
 
     /// Render a Bolero component in a Razor page.
     [<Extension>]
     static member RenderComponentAsync<'T when 'T :> IComponent>(html: IHtmlHelper, config: IBoleroHostConfig, [<Optional; DefaultParameterValue null>] parameters: obj) =
-        Components.Impl.renderComponentAsync html typeof<'T> config parameters
+        Components.Rendering.renderComponentAsync html typeof<'T> config parameters
 
     /// Render the given page in the HTTP response body.
     [<Extension>]
     static member RenderPage(this: HttpContext, page: Node) : Task = upcast task {
         let htmlHelper = this.RequestServices.GetRequiredService<IHtmlHelper>()
-        let! body = Components.Impl.renderComp typeof<Components.Page> this htmlHelper Components.Impl.Page (dict ["Node", box page])
-        let body = body |> System.Text.Encoding.UTF8.GetBytes
+        let boleroConfig = this.RequestServices.GetRequiredService<IBoleroHostConfig>()
+        let body =
+            Components.Rendering.renderPage page this htmlHelper boleroConfig
+            |> System.Text.Encoding.UTF8.GetBytes
         return! this.Response.Body.WriteAsync(ReadOnlyMemory body)
     }
 

--- a/src/Bolero.Server/Html.fs
+++ b/src/Bolero.Server/Html.fs
@@ -20,6 +20,7 @@
 
 namespace Bolero.Server
 
+open System
 open Microsoft.AspNetCore.Components
 open Bolero
 open Bolero.Builders
@@ -107,13 +108,14 @@ module Html =
     open Bolero.Html
 
     /// Insert a Blazor component inside a static page.
+    [<Obsolete "Use comp instead">]
     let rootComp<'T when 'T :> IComponent> =
         ComponentWithAttrsAndNoChildrenBuilder<Components.RootComponent>(attrs {
             "ComponentType" => typeof<'T>
         })
 
     /// Insert the required scripts to run Blazor components.
-    let boleroScript = comp<Components.BoleroScript> { attr.empty() }
+    let boleroScript = comp<Components.BoleroScript>
 
     /// Create a doctype declaration.
     let doctype (decl: string) = rawHtml $"<!DOCTYPE {decl}>\n"

--- a/tests/Server/Page.fs
+++ b/tests/Server/Page.fs
@@ -34,7 +34,7 @@ let index = doctypeHtml {
     body {
         div {
             attr.id "main"
-            rootComp<Bolero.Test.Client.Main.MyApp>
+            comp<Bolero.Test.Client.Main.MyApp>
         }
         hr
         a {


### PR DESCRIPTION
When rendering the static part of a page defined with Bolero.Html, prerendering does not work (see #261). It seems that using Blazor's renderer in a nested way (first for the page component, and then inside for the `rootComp` component) is not supported: the nested rendering gets queued as a task, and executed too late.

This PR fixes this issue by using a simple custom renderer for the page instead of invoking Blazor's RenderComponentAsync.

* Fix #261
* Obsolete `rootComp`, because with this new renderer, `comp` can be used directly.
* Add `Bolero.Server.Components.Rendering.renderPlain : Node -> string` which renders a Node into a string (see #275). Components are ignored, including boleroScript.