### PR TITLE
Allow dedicated configuration per remote service

### DIFF
--- a/tests/Remoting.Client/Main.fs
+++ b/tests/Remoting.Client/Main.fs
@@ -248,7 +248,9 @@ module Program =
     let Main args =
         let builder = WebAssemblyHostBuilder.CreateDefault(args)
         builder.RootComponents.Add<MyApp>("#main")
-        builder.Services.AddRemoting(builder.HostEnvironment) |> ignore
+        builder.Services.AddRemoting<MyApi>(builder.HostEnvironment) |> ignore
+        builder.Services.AddRemoting(configureHttpClient = fun http ->
+            http.BaseAddress <- System.Uri "http://this-shouldnt-be-used-by-myapi") |> ignore
         builder.Services.AddScoped<AuthenticationStateProvider, DummyAuthProvider>() |> ignore
         builder.Services.AddAuthorizationCore() |> ignore
         builder.Build().RunAsync() |> ignore


### PR DESCRIPTION
Adds type-parameterized versions of client-side `AddRemoting()` methods that configure remoting for the given remote service type.

This makes it possible, for example, to configure the HttpClient with different base URIs (#280).

The non-parameterized `AddRemoting()` remains and is used for any services that don't have a corresponding typed `AddRemoting<T>()` call.

```fsharp
type ServiceA = { ... }
type ServiceB = { ... }
type ServiceC = { ... }

// ServiceA calls will go to http://base-uri-for-service-a.com
builder.Services.AddRemoting<ServiceA>(configureHttpClient = fun http ->
    http.BaseAddress <- System.Uri "http://base-uri-for-service-a.com") |> ignore

// ServiceB and ServiceC calls will go to the website's base URL
builder.Services.AddRemoting(builder.HostEnvironment) |> ignore
```