### PR TITLE
[#296] Add CSS isolation with *.bolero.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
     where `CssScopes` is a compiler-generated module and `MyApp` is the name of the style file without `.bolero.css` extension.
 
+    The MSBuild item `BoleroScopedCss` can be used to add component-specific CSS files.
+    Its metadata `ScopeName` determines the name of the corresponding value in the `CssScopes` module.
+
 ## 0.21
 
 * [#261](https://github.com/fsbolero/Bolero/issues/261) Fix prerendering of components inside server-side Bolero.Html.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
 
 * [#288](https://github.com/fsbolero/Bolero/issues/288) Update Elmish to [version 4](https://elmish.github.io/elmish/release_notes.html#4.0.1).
 
+* [#296](https://github.com/fsbolero/Bolero/issues/296) Add [CSS isolation](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/css-isolation) for Bolero components.
+    Files ending in `.bolero.css` are treated as component-specific styles which can be applied to a component type with the following property:
+
+    ```fsharp
+    override _.CssScope = CssScopes.MyApp
+    ```
+
+    where `CssScopes` is a compiler-generated module and `MyApp` is the name of the style file without `.bolero.css` extension.
+
 ## 0.21
 
 * [#261](https://github.com/fsbolero/Bolero/issues/261) Fix prerendering of components inside server-side Bolero.Html.

--- a/src/Bolero.Build/Bolero.Build.csproj
+++ b/src/Bolero.Build/Bolero.Build.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Bolero.Build/Bolero.Build.props
+++ b/src/Bolero.Build/Bolero.Build.props
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <BoleroScopedCss Include="**/*.bolero.css" />
+    <BoleroScopedCss Include="**/*.bolero.css">
+      <!-- For "Foo/Bar.bolero.css", %(Filename) is "Bar.bolero". GetFileName() gives us "Bar". -->
+      <ScopeName>$([System.IO.Path]::GetFileName('%(Filename)')</ScopeName>
+    </BoleroScopedCss>
   </ItemGroup>
 </Project>

--- a/src/Bolero.Build/Bolero.Build.props
+++ b/src/Bolero.Build/Bolero.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <BoleroScopedCss Include="**/*.bolero.css" />
+  </ItemGroup>
+</Project>

--- a/src/Bolero.Build/Bolero.Build.targets
+++ b/src/Bolero.Build/Bolero.Build.targets
@@ -4,9 +4,33 @@
     <BoleroTaskAssemblyPath>$(MSBuildThisFileDirectory)..\tools\Bolero.Build.dll</BoleroTaskAssemblyPath>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly><!-- See https://github.com/fsbolero/Bolero/issues/279 -->
   </PropertyGroup>
-  <UsingTask AssemblyFile="$(BoleroTaskAssemblyPath)" TaskName="Bolero.Build.BoleroTask"
-    Condition="'$(BoleroStripAssemblies)' != 'False'" />
-  <Target Name="StripFSharp" AfterTargets="ILLink" Condition="'$(BoleroStripAssemblies)' != 'False'">
-    <BoleroTask AssembliesDir="$(IntermediateLinkDir)" ReferencePath="@(ManagedAssemblyToLink)" />
+  <PropertyGroup>
+    <_BoleroScopedCssSourceFile>$(BaseIntermediateOutputPath)CssScopes.fs</_BoleroScopedCssSourceFile>
+  </PropertyGroup>
+
+  <UsingTask AssemblyFile="$(BoleroTaskAssemblyPath)" TaskName="Bolero.Build.BoleroStripFSharpMetadata"
+             Condition="'$(BoleroStripAssemblies)' != 'False'" />
+  <UsingTask AssemblyFile="$(BoleroTaskAssemblyPath)" TaskName="Bolero.Build.BoleroApplyCssScopes" />
+
+  <!-- Strip F# metadata embedded files -->
+  <Target Name="_BoleroStripFSharpMetadata" AfterTargets="ILLink" Condition="'$(BoleroStripAssemblies)' != 'False'">
+    <BoleroStripFSharpMetadata AssembliesDir="$(IntermediateLinkDir)" ReferencePath="@(ManagedAssemblyToLink)" />
+  </Target>
+
+  <!-- Generate the CSS Scope identifier for *.bolero.css -->
+  <Target Name="_BoleroComputeCssScope" DependsOnTargets="_ResolveCssScopes">
+    <ComputeCssScope ScopedCssInput="@(BoleroScopedCss)" Targetname="$(TargetName)">
+      <Output TaskParameter="ScopedCss" ItemName="_BoleroScopedCss" />
+    </ComputeCssScope>
+  </Target>
+
+  <!-- Generate CssScopes.fs and add *.bolero.css to Razor's _ScopedCss -->
+  <Target Name="_BoleroApplyCssScopes" DependsOnTargets="_BoleroComputeCssScope" BeforeTargets="_ResolveScopedCssOutputs;CoreCompile"
+          Inputs="@(_BoleroScopedCss)" Outputs="$(_BoleroScopedCssSourceFile)">
+    <BoleroApplyCssScopes ScopedCss="@(_BoleroScopedCss)" ScopedCssSourceFile="$(_BoleroScopedCssSourceFile)" />
+    <ItemGroup>
+      <CompileBefore Include="$(_BoleroScopedCssSourceFile)" />
+      <_ScopedCss Include="@(_BoleroScopedCss)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Bolero.Build/BoleroApplyCssScopes.cs
+++ b/src/Bolero.Build/BoleroApplyCssScopes.cs
@@ -19,9 +19,9 @@ namespace Bolero.Build
             file.WriteLine("module internal CssScopes");
             foreach (var item in ScopedCss)
             {
-                var filename = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(item.ItemSpec));
+                var scopeName = item.GetMetadata("ScopeName");
                 var scope = item.GetMetadata("CssScope");
-                file.WriteLine($"""let [<Literal>] ``{filename}`` = "{scope}";""");
+                file.WriteLine($"""let [<Literal>] ``{scopeName}`` = "{scope}";""");
             }
             return true;
         }

--- a/src/Bolero.Build/BoleroApplyCssScopes.cs
+++ b/src/Bolero.Build/BoleroApplyCssScopes.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Bolero.Build
+{
+    public class BoleroApplyCssScopes : Task
+    {
+        [Required]
+        public ITaskItem[] ScopedCss { get; set; }
+
+        [Required]
+        public string ScopedCssSourceFile { get; set; }
+
+        public override bool Execute()
+        {
+            using var file = new StreamWriter(ScopedCssSourceFile, false);
+            file.WriteLine("[<System.Runtime.CompilerServices.CompilerGenerated>]");
+            file.WriteLine("module internal CssScopes");
+            foreach (var item in ScopedCss)
+            {
+                var filename = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(item.ItemSpec));
+                var scope = item.GetMetadata("CssScope");
+                file.WriteLine($"""let [<Literal>] ``{filename}`` = "{scope}";""");
+            }
+            return true;
+        }
+    }
+}

--- a/src/Bolero.Build/BoleroStripFSharpMetadata.cs
+++ b/src/Bolero.Build/BoleroStripFSharpMetadata.cs
@@ -27,10 +27,12 @@ using Mono.Cecil;
 
 namespace Bolero.Build {
 
-    public class BoleroTask : Task {
+    public class BoleroStripFSharpMetadata : Task {
 
+        [Required]
         public ITaskItem[] AssembliesDir { get; set; }
 
+        [Required]
         public ITaskItem[] ReferencePath { get; set; }
 
         private void StripFile(string f, IAssemblyResolver resolver) {

--- a/src/Bolero.Build/paket.template
+++ b/src/Bolero.Build/paket.template
@@ -8,6 +8,7 @@ description
 authors
     Loic Denuziere
 files
+    Bolero.Build.props ==> build
     Bolero.Build.targets ==> build
     bin/Release/netstandard2.0/Bolero.Build.dll ==> tools
     bin/Release/netstandard2.0/Mono.Cecil.dll ==> tools

--- a/src/Bolero.Html/Builders.fs
+++ b/src/Bolero.Html/Builders.fs
@@ -22,6 +22,7 @@ namespace Bolero.Builders
 
 open System
 open Microsoft.AspNetCore.Components
+open Microsoft.AspNetCore.Components.Rendering
 open Bolero
 
 /// <summary>Render the current element or component's reference.</summary>
@@ -111,6 +112,15 @@ and [<Sealed; NoComparison; NoEquality>] ElementBuilder =
     val public Name: string
     new(name) = { Name = name }
 
+    member inline private _.AddCssScope(c: obj, b: RenderTreeBuilder, i: int) =
+        match c with
+        | :? Component as c ->
+            match c.CssScope with
+            | null -> ()
+            | s -> b.AddAttribute(i, s)
+        | _ -> ()
+        i + 1
+
     member inline _.Yield([<InlineIfLambda>] attr: Attr) = attr
     member inline _.Yield([<InlineIfLambda>] ref: RefContent) = ref
     member inline _.Yield([<InlineIfLambda>] node: Node) = node
@@ -193,6 +203,7 @@ and [<Sealed; NoComparison; NoEquality>] ElementBuilder =
     member inline this.Run([<InlineIfLambda>] content: Node) =
         Node(fun c b i ->
             b.OpenElement(i, this.Name)
+            let i = this.AddCssScope(c, b, i)
             let i = content.Invoke(c, b, i + 1)
             b.CloseElement()
             i)
@@ -200,6 +211,7 @@ and [<Sealed; NoComparison; NoEquality>] ElementBuilder =
     member inline this.Run([<InlineIfLambda>] content: Attr) =
         Node(fun c b i ->
             b.OpenElement(i, this.Name)
+            let i = this.AddCssScope(c, b, i)
             let i = content.Invoke(c, b, i + 1)
             b.CloseElement()
             i)
@@ -207,6 +219,7 @@ and [<Sealed; NoComparison; NoEquality>] ElementBuilder =
     member inline this.Run([<InlineIfLambda>] content: RefContent) =
         Node(fun c b i ->
             b.OpenElement(i, this.Name)
+            let i = this.AddCssScope(c, b, i)
             let i = content.Invoke(c, b, i + 1)
             b.CloseElement()
             i)
@@ -214,6 +227,7 @@ and [<Sealed; NoComparison; NoEquality>] ElementBuilder =
     member inline this.Run([<InlineIfLambda>] content: ChildAndRefContent) =
         Node(fun c b i ->
             b.OpenElement(i, this.Name)
+            let i = this.AddCssScope(c, b, i)
             let i = content.Invoke(c, b, i + 1)
             b.CloseElement()
             i)

--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -34,6 +34,9 @@ open Elmish
 type Component() =
     inherit ComponentBase()
 
+    abstract CssScope : string
+    default _.CssScope = null
+
     override this.BuildRenderTree(builder) =
         base.BuildRenderTree(builder)
         this.Render().Invoke(this, builder, 0) |> ignore

--- a/tests/Client/Client.fsproj
+++ b/tests/Client/Client.fsproj
@@ -12,6 +12,7 @@
     <Content Include="MyApp.bolero.css" />
     <Compile Include="Startup.fs" />
     <None Include="paket.references" />
+    <BoleroScopedCss Update="MyApp.bolero.css" ScopeName="CustomScope" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bolero.Html\Bolero.Html.fsproj" />

--- a/tests/Client/Client.fsproj
+++ b/tests/Client/Client.fsproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <Import Project="..\..\src\Bolero.Build\Bolero.Build.props" />
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <DefineConstants Condition="'$(GhPages)' != ''">$(DefineConstants);GHPAGES</DefineConstants>
@@ -8,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.fs" />
+    <Content Include="MyApp.bolero.css" />
     <Compile Include="Startup.fs" />
     <None Include="paket.references" />
   </ItemGroup>

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -349,7 +349,7 @@ let view js model dispatch =
 type MyApp() =
     inherit ProgramComponent<Model, Message>()
 
-    override _.CssScope = CssScopes.MyApp
+    override _.CssScope = CssScopes.CustomScope
 
     override this.Program =
         Program.mkProgram (fun _ -> initModel(), []) update (view this.JSRuntime)

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -328,7 +328,6 @@ let view js model dispatch =
     concat {
         rawHtml """
             <div style="color:gray">The links below should have blue background based on the current page.</div>
-            <style>.active { background: lightblue; }</style>
         """
         p {
             navLink NavLinkMatch.All { router.HRef Form; "Form" }
@@ -349,6 +348,8 @@ let view js model dispatch =
 
 type MyApp() =
     inherit ProgramComponent<Model, Message>()
+
+    override _.CssScope = CssScopes.MyApp
 
     override this.Program =
         Program.mkProgram (fun _ -> initModel(), []) update (view this.JSRuntime)

--- a/tests/Client/MyApp.bolero.css
+++ b/tests/Client/MyApp.bolero.css
@@ -1,0 +1,3 @@
+::deep .active {
+  background: lightblue;
+}

--- a/tests/Client/wwwroot/index.html
+++ b/tests/Client/wwwroot/index.html
@@ -4,6 +4,7 @@
     <title>Bolero (client side)</title>
     <meta charset="UTF-8" />
     <base href="/" />
+    <link rel="stylesheet" href="Client.styles.css">
   </head>
   <body>
     <div id="main"></div>

--- a/tests/Remoting.Client/Remoting.Client.fsproj
+++ b/tests/Remoting.Client/Remoting.Client.fsproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <Import Project="..\..\src\Bolero.Build\Bolero.Build.props" />
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <BoleroTaskAssemblyPath>$(MSBuildThisFileDirectory)..\..\src\Bolero.Build\bin\$(Configuration)\netstandard2.0\Bolero.Build.dll</BoleroTaskAssemblyPath>

--- a/tests/Server/Page.fs
+++ b/tests/Server/Page.fs
@@ -30,6 +30,7 @@ let index = doctypeHtml {
         title { "Bolero (server side)" }
         meta { attr.charset "UTF-8" }
         ``base`` { attr.href "/" }
+        link { attr.rel "stylesheet"; attr.href "Client.styles.css" }
     }
     body {
         div {

--- a/tests/Unit.Client/Unit.Client.fsproj
+++ b/tests/Unit.Client/Unit.Client.fsproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <Import Project="..\..\src\Bolero.Build\Bolero.Build.props" />
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <BoleroTaskAssemblyPath>$(MSBuildThisFileDirectory)..\..\src\Bolero.Build\bin\$(Configuration)\netstandard2.0\Bolero.Build.dll</BoleroTaskAssemblyPath>


### PR DESCRIPTION
Fixes #296.

The solution implemented is:

* A component-specific CSS file has extension `*.bolero.css`. It turns out that using `*.razor.css` is a no-go because the Razor SDK actively checks that any `*.razor.css` has a corresponding `*.razor`.

    This can be customized using the `BoleroScopedCss` MSBuild item:

    ```xml
    <ItemGroup>
      <!-- Use *.css instead of *.bolero.css. See below for the meaning of ScopeName -->
      <BoleroScopedCss Remove="**/*.bolero.css" />
      <BoleroScopedCss Include="**/*.css" ScopeName="%(Filename)" />
    </ItemGroup>
    ```

* The MSBuild task adds these CSS files to the Razor SDK's list of files to add to the generated `ASSEMBLY_NAME.styles.css`. See fsbolero/Template#39 for the addition of this file to the project template, which is also needed for CSS isolation in imported components.

* The MSBuild task also generates an internal F# module `CssScopes` that contains one value per component-specific CSS file. This value is the unique token that the Razor SDK generates and adds to the CSS selectors.

    The name of the value is determined by the `ScopeName` metadata of the corresponding `BoleroScopedCss` MSBuild item. It can therefore be customized:

    ```xml
    <ItemGroup>
      <BoleroScopedCss Update="MyFile.bolero.css" ScopeName="MyCustomScope" />
    </ItemGroup>
    ```

* To associate `MyFile.bolero.css` with a given component, the user needs to add the following line to the component:
    ```fsharp
    override _.CssScope = CssScopes.MyFile
    // Or "CssScopes.MyCustomScope", when using the above customization on BoleroScopedCss.
    ```
    The renderer will then be able to use this to add the appropriate attribute to every element in the component.

In the end, no type provider is needed: all the compile-time work is done by the MSBuild task that takes the SDK-generated token and puts it in the `CssScopes` module.