### PR TITLE
[#290] Templating: Add HTML element references

### DIFF
--- a/src/Bolero.Templating.Provider/Bolero.Templating.Provider.fsproj
+++ b/src/Bolero.Templating.Provider/Bolero.Templating.Provider.fsproj
@@ -19,6 +19,7 @@
     </Compile>
     <Compile Include="..\Bolero\Attr.fs" Link="Attr.fs" />
     <Compile Include="..\Bolero\Node.fs" Link="Node.fs" />
+    <Compile Include="..\Bolero\Ref.fs" Link="Ref.fs" />
     <Compile Include="..\Bolero\TemplatingInternals.fs" Link="TemplatingInternals.fs" />
     <Compile Include="Utilities.fs" />
     <Compile Include="Path.fs" />

--- a/src/Bolero.Templating.Provider/CodeGen.fs
+++ b/src/Bolero.Templating.Provider/CodeGen.fs
@@ -43,6 +43,7 @@ let MakeCtor (holes: Parsing.Vars) =
                 | Parsing.HoleType.DataBinding _ -> <@ box (null, Events.NoOp<ChangeEventArgs>()) @>
                 | Parsing.HoleType.Attribute -> <@ box (Attr.Empty()) @>
                 | Parsing.HoleType.AttributeValue -> <@ null @>
+                | Parsing.HoleType.Ref -> <@ null @>
         ]
         <@@ (%getThis args).Holes <- %holes @@>)
 
@@ -95,6 +96,11 @@ let HoleMethodBodies (holeType: Parsing.HoleType) : (ProvidedParameter list * (E
         [
             ["value" => typeof<obj>], fun args ->
                 <@@ %%args.[1] @@>
+        ]
+    | Parsing.HoleType.Ref ->
+        [
+            ["value" => typeof<HtmlRef>], fun args ->
+                <@@ box (%%args.[1]: HtmlRef) @@>
         ]
 
 let MakeHoleMethods (holeName: string) (holeType: Parsing.HoleType) (index: int) (containerTy: ProvidedTypeDefinition) =

--- a/src/Bolero.Templating.Provider/Parsing.fs
+++ b/src/Bolero.Templating.Provider/Parsing.fs
@@ -48,6 +48,8 @@ type HoleType =
     | Attribute
     /// An attribute value hole.
     | AttributeValue
+    /// A `ref` attribute hole.
+    | Ref
 
 module HoleType =
 
@@ -141,6 +143,7 @@ type Expr =
     | WrapVars of vars: list<VarSubstitution> * expr: Expr
     | Fst of varName: string
     | Snd of varName: string
+    | HtmlRef of varName: string
 
 type Vars = Map<string, HoleType>
 
@@ -295,6 +298,8 @@ let ParseAttribute (ownerNode: HtmlNode) (attr: HtmlAttribute) : Parsed =
     | _, [VarContent varName] ->
         if name = "attr" then
             WithVars (Map [varName, Attribute]) parsed.Expr
+        elif name = "ref" then
+            WithVars (Map [varName, HoleType.Ref]) [HtmlRef varName]
         elif name.StartsWith "on" then
             MakeEventHandler name varName
         else

--- a/src/Bolero/Bolero.fsproj
+++ b/src/Bolero/Bolero.fsproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <Compile Include="Attr.fs" />
     <Compile Include="Node.fs" />
-    <Compile Include="TemplatingInternals.fs" />
     <Compile Include="Router.fs" />
     <Compile Include="ProgramRun.fs" />
     <Compile Include="Components.fs" />
     <Compile Include="Virtualize.fs" />
     <Compile Include="Ref.fs" />
+    <Compile Include="TemplatingInternals.fs" />
     <Compile Include="Remoting.fs" />
     <Compile Include="Remoting.Client.fs" />
     <Compile Include="Cmd.fs" />

--- a/src/Bolero/TemplatingInternals.fs
+++ b/src/Bolero/TemplatingInternals.fs
@@ -59,7 +59,10 @@ type Events =
 type Ref =
 
     static member MakeAttr(ref: HtmlRef) =
-        Attr(fun _ b i -> ref.Render(b, i))
+        if isNull (box ref) then
+            Attr.Empty()
+        else
+            Attr(fun _ b i -> ref.Render(b, i))
 
 type TemplateNode() =
     /// For internal use only.

--- a/src/Bolero/TemplatingInternals.fs
+++ b/src/Bolero/TemplatingInternals.fs
@@ -56,6 +56,11 @@ type Events =
             f.Invoke(unbox<bool> e.Value)
         )
 
+type Ref =
+
+    static member MakeAttr(ref: HtmlRef) =
+        Attr(fun _ b i -> ref.Render(b, i))
+
 type TemplateNode() =
     /// For internal use only.
     member val Holes : obj[] = null with get, set

--- a/src/tpdummy/Microsoft.AspNetCore.Components/Library.fs
+++ b/src/tpdummy/Microsoft.AspNetCore.Components/Library.fs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Components
 type ChangeEventArgs = member _.Value = obj()
 type IComponent = interface end
 type ComponentBase() = interface IComponent
+type ElementReference = class end
 
 namespace Microsoft.AspNetCore.Components.Rendering
 
@@ -20,6 +21,8 @@ type RenderTreeBuilder =
     member _.AddMarkupContent(_: int, _: string) : unit = raise (NotImplementedException())
     member _.OpenRegion(_: int) : unit = raise (NotImplementedException())
     member _.CloseRegion() : unit = raise (NotImplementedException())
+    member _.AddComponentReferenceCapture(_: int, _: Action<obj>) = raise (NotImplementedException())
+    member _.AddElementReferenceCapture(_: int, _: Action<ElementReference>) = raise (NotImplementedException())
 
 namespace Microsoft.AspNetCore.Components
 

--- a/tests/Unit.Client/Templating.fs
+++ b/tests/Unit.Client/Templating.fs
@@ -174,7 +174,7 @@ type BindTester() =
             .VarOnchange3(this.VarOnchange3, fun (v: float) -> this.VarOnchange3 <- v)
             .Elt()
 
-type Refs = Template<"""<button class="template-ref" ref="${MyRef}" onclick="${Click}">Initial ref content</button>""">
+type Refs = Template<"""<button class="${Class}" ref="${MyRef}" onclick="${Click}">Initial ref content</button>""">
 
 type RefTester() =
     inherit Component()
@@ -185,13 +185,19 @@ type RefTester() =
     member val JSRuntime = Unchecked.defaultof<IJSRuntime> with get, set
 
     override this.Render() =
-        Refs()
-            .MyRef(elt)
-            .Click(fun _ ->
-                match elt.Value with
-                | Some elt -> this.JSRuntime.InvokeVoidAsync("setContent", elt, "Template ref is bound") |> ignore
-                | None -> ())
-            .Elt()
+        concat {
+            Refs()
+                .MyRef(elt)
+                .Class("template-ref")
+                .Click(fun _ ->
+                    match elt.Value with
+                    | Some elt -> this.JSRuntime.InvokeVoidAsync("setContent", elt, "Template ref is bound") |> ignore
+                    | None -> ())
+                .Elt()
+
+            // Check that not passing the ref doesn't break anything.
+            Refs().Elt()
+        }
 
 type ``Regression #11`` = Template<"""<span class="${Hole}">${Hole}</span>""">
 

--- a/tests/Unit.Client/Templating.fs
+++ b/tests/Unit.Client/Templating.fs
@@ -20,9 +20,12 @@
 
 module Bolero.Tests.Client.Templating
 
+open System.Threading.Tasks
 open Bolero
 open Bolero.Html
+open Microsoft.AspNetCore.Components
 open Microsoft.AspNetCore.Components.Web
+open Microsoft.JSInterop
 
 type Inline = Template<"""
     <div class="inline">
@@ -171,6 +174,25 @@ type BindTester() =
             .VarOnchange3(this.VarOnchange3, fun (v: float) -> this.VarOnchange3 <- v)
             .Elt()
 
+type Refs = Template<"""<button class="template-ref" ref="${MyRef}" onclick="${Click}">Initial ref content</button>""">
+
+type RefTester() =
+    inherit Component()
+
+    let elt = HtmlRef()
+
+    [<Inject>]
+    member val JSRuntime = Unchecked.defaultof<IJSRuntime> with get, set
+
+    override this.Render() =
+        Refs()
+            .MyRef(elt)
+            .Click(fun _ ->
+                match elt.Value with
+                | Some elt -> this.JSRuntime.InvokeVoidAsync("setContent", elt, "Template ref is bound") |> ignore
+                | None -> ())
+            .Elt()
+
 type ``Regression #11`` = Template<"""<span class="${Hole}">${Hole}</span>""">
 
 type ``Regression #256`` = Template<"""
@@ -214,4 +236,5 @@ let Tests() =
             .Elt()
         comp<EventTester>
         comp<BindTester>
+        comp<RefTester>
     }

--- a/tests/Unit/Tests/Templating.fs
+++ b/tests/Unit/Tests/Templating.fs
@@ -231,6 +231,13 @@ module Templating =
         testNull <@ elt.ById("Nested2") @>
 
     [<Test>]
+    let ``Template element ref``() =
+        let btn = elt.ByClass("template-ref")
+        testNotNull <@ btn @>
+        btn.Click()
+        elt.Eventually <@ btn.Text = "Template ref is bound" @>
+
+    [<Test>]
     let ``Regression #11: common hole in attrs and children``() =
         test <@ elt.ByClass("regression-11").Text = "regression-11" @>
 


### PR DESCRIPTION
Example use:

```fsharp
type Tpl = """<div ref="${MyDiv}"></div>"""

type MyComponent() =
    inherit Component()

    let ref = HtmlRef()

    override _.Render() =
        Tpl()
            .MyDiv(ref)
            .Elt()
```