### PR TITLE
[#309] Router query parameters

### DIFF
--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -33,7 +33,7 @@ type Page =
     | [<EndPoint "/">] Form
     | [<EndPoint "/collection">] Collection
     | [<EndPoint "/collection-item/{key}">] Item of key: int * model: PageModel<int>
-    | [<EndPoint "/lazy?{value}&v2={value2}">] Lazy of value: int * value2: string
+    | [<EndPoint "/lazy?{value}&v2={value2}">] Lazy of value: int * value2: string option
     | [<EndPoint "/virtual">] Virtual
 
 type Item =
@@ -335,7 +335,9 @@ let view js model dispatch =
             text " "
             navLink NavLinkMatch.Prefix { router.HRef Collection; "Collection" }
             text " "
-            navLink NavLinkMatch.Prefix { attr.href (router.Link (Lazy (123, "abc"))); "Lazy" }
+            navLink NavLinkMatch.Prefix { attr.href (router.Link (Lazy (123, Some "abc"))); "Lazy" }
+            text " "
+            navLink NavLinkMatch.Prefix { attr.href (router.Link (Lazy (123, None))); "Lazy" }
             text " "
             navLink NavLinkMatch.All { router.HRef Virtual; "Virtual" }
         }

--- a/tests/Unit.Client/Routing.fs
+++ b/tests/Unit.Client/Routing.fs
@@ -47,7 +47,7 @@ type Page =
     | [<EndPoint "/with-rest-array/{*rest}">] WithRestArray of rest: (int * string)[]
     | [<EndPoint "/with-model">] WithModel of PageModel<int>
     | [<EndPoint "/with-model-args/{arg}">] WithModelAndArgs of arg: int * PageModel<string>
-    | [<EndPoint "/with-query/{arg}?named={n}&{implicit}&{optional}">] WithQuery of arg: int * n: int * implicit: int * optional: int option
+    | [<EndPoint "/with-query/{arg}?named={n}&{implicit}&{optional}&{voptional}">] WithQuery of arg: int * n: int * implicit: int * optional: int option * voptional: int voption
 
 and InnerPage =
     | [<EndPoint "/">] InnerHome
@@ -114,7 +114,7 @@ let rec pageClass = function
     | WithRestArray a -> $"""withrestarray-{a |> Seq.map (fun (i, s) -> $"{i}-{s}") |> String.concat "-"}"""
     | WithModel _ -> "withmodel"
     | WithModelAndArgs (a, _) -> $"withmodelargs-{a}"
-    | WithQuery(a, b, c, d) -> $"withquery-{a}-{b}-{c}-{d}"
+    | WithQuery(a, b, c, d, e) -> $"withquery-{a}-{b}-{c}-{d}-{e}"
 
 let innerlinks =
     [
@@ -166,8 +166,8 @@ let baseLinks =
             "/with-rest-array/1/foo/2/bar",     WithRestArray [|(1, "foo"); (2, "bar")|]
             "/with-model",                      WithModel { Model = Unchecked.defaultof<_> }
             "/with-model-args/42",              WithModelAndArgs(42, { Model = Unchecked.defaultof<_> })
-            "/with-query/42?implicit=2&named=1&optional=3", WithQuery(42, 1, 2, Some 3)
-            "/with-query/42?implicit=5&named=4", WithQuery(42, 4, 5, None)
+            "/with-query/42?implicit=2&named=1&optional=3", WithQuery(42, 1, 2, Some 3, ValueNone)
+            "/with-query/42?implicit=5&named=4&voptional=3", WithQuery(42, 4, 5, None, ValueSome 3)
         ]
         for link, page in innerlinks do
             yield "/with-union" + link,                     WithUnion page

--- a/tests/Unit.Client/Routing.fs
+++ b/tests/Unit.Client/Routing.fs
@@ -47,6 +47,7 @@ type Page =
     | [<EndPoint "/with-rest-array/{*rest}">] WithRestArray of rest: (int * string)[]
     | [<EndPoint "/with-model">] WithModel of PageModel<int>
     | [<EndPoint "/with-model-args/{arg}">] WithModelAndArgs of arg: int * PageModel<string>
+    | [<EndPoint "/with-query/{arg}?named={n}&{implicit}&{optional}">] WithQuery of arg: int * n: int * implicit: int * optional: int option
 
 and InnerPage =
     | [<EndPoint "/">] InnerHome
@@ -113,6 +114,7 @@ let rec pageClass = function
     | WithRestArray a -> $"""withrestarray-{a |> Seq.map (fun (i, s) -> $"{i}-{s}") |> String.concat "-"}"""
     | WithModel _ -> "withmodel"
     | WithModelAndArgs (a, _) -> $"withmodelargs-{a}"
+    | WithQuery(a, b, c, d) -> $"withquery-{a}-{b}-{c}-{d}"
 
 let innerlinks =
     [
@@ -164,6 +166,8 @@ let baseLinks =
             "/with-rest-array/1/foo/2/bar",     WithRestArray [|(1, "foo"); (2, "bar")|]
             "/with-model",                      WithModel { Model = Unchecked.defaultof<_> }
             "/with-model-args/42",              WithModelAndArgs(42, { Model = Unchecked.defaultof<_> })
+            "/with-query/42?implicit=2&named=1&optional=3", WithQuery(42, 1, 2, Some 3)
+            "/with-query/42?implicit=5&named=4", WithQuery(42, 4, 5, None)
         ]
         for link, page in innerlinks do
             yield "/with-union" + link,                     WithUnion page


### PR DESCRIPTION
Add support for query parameters in inferred routers.

```fsharp
type Page =
    // Use ?name={argName} to indicate a query parameter
    | [<EndPoint "/list?start={s}&count={c}">] List of s: int * c: int

    // You can of course mix path and query parameters
    | [<EndPoint "/user/{userId}?count={c}">] User of userId: string * c: int

    // ?{argName} is equivalent to ?argName={argName}
    | [<EndPoint "/posts?{start}&{count}">] Posts of start: int * count: int

    // The parameter is optional if it has type option or voption
    | [<EndPoint "/articles?{start}&{count}">] Articles of start: int option * count: int voption
```