### PR TITLE
Add Router.withNotFound to handle unknown URL

### DIFF
--- a/src/Bolero/Components.fs
+++ b/src/Bolero/Components.fs
@@ -164,7 +164,8 @@ and [<AbstractClass>]
                     this.Log.LogInformation("Navigating to external address: {0}", e.Location)
                     this.NavigationManager.NavigateTo(e.Location, forceLoad = true)
                 else
-                    this.Log.LogInformation("No route found for this path: {0}", uri))
+                    this.Log.LogInformation("No route found for this path: {0}", uri)
+                    Option.iter dispatch router.NotFound)
 
     member internal this.GetCurrentUri() =
         let uri = this.NavigationManager.Uri
@@ -217,7 +218,9 @@ and [<AbstractClass>]
         | Some msg ->
             update msg initModel
         | None ->
-            initModel, []
+            match r.NotFound with
+            | Some msg -> update msg initModel
+            | None -> initModel, []
 
     override this.OnAfterRenderAsync(firstRender) =
         if firstRender then

--- a/src/Bolero/Router.fs
+++ b/src/Bolero/Router.fs
@@ -921,8 +921,20 @@ module Router =
             (makeMessage: 'ep -> 'msg) (getEndPoint: 'model -> 'ep) =
         inferWithModel makeMessage getEndPoint ignore
 
-    let withNotFound (notFound: 'ep) (r: Router<'ep, 'model, 'msg>) =
-        { r with notFound = Some notFound }
+    /// <summary>
+    /// Indicate the endpoint to switch to if the user initially navigates to an unknown uri.
+    /// </summary>
+    let withNotFound (notFound: 'ep) (router: Router<'ep, 'model, 'msg>) =
+        { router with notFound = Some notFound }
+
+    /// <summary>
+    /// Indicate the message to send if the user initially navigates to an unknown uri.
+    /// </summary>
+    let withNotFoundMsg (notFound: 'msg) (router: IRouter<'model, 'msg>) =
+        { new IRouter<'model, 'msg> with
+            member _.GetRoute(model) = router.GetRoute(model)
+            member _.SetRoute(uri) = router.SetRoute(uri)
+            member _.NotFound = Some notFound }
 
     /// <summary>
     /// An empty PageModel. Used when constructing an endpoint to pass to methods such as <see cref="M:Router`3.Link" />.

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -31,6 +31,7 @@ open Microsoft.AspNetCore.Components.Web.Virtualization
 
 type Page =
     | [<EndPoint "/">] Form
+    | [<EndPoint "/not-found">] NotFound
     | [<EndPoint "/collection">] Collection
     | [<EndPoint "/collection-item/{key}">] Item of key: int * model: PageModel<int>
     | [<EndPoint "/lazy?{value}&v2={value2}">] Lazy of value: int * value2: string option
@@ -102,9 +103,11 @@ let initModel _ =
     }
 
 let defaultPageModel = function
-    | Form | Collection | Lazy _ | Virtual -> ()
+    | Form | Collection | Lazy _ | Virtual | NotFound -> ()
     | Item (_, m) -> Router.definePageModel m 10
-let router = Router.inferWithModel SetPage (fun m -> m.page) defaultPageModel
+let router =
+    Router.inferWithModel SetPage (fun m -> m.page) defaultPageModel
+    |> Router.withNotFound NotFound
 
 type MyRemoting =
     {
@@ -347,6 +350,7 @@ let view js model dispatch =
             | Item (k, m) -> ecomp<ViewItemPage,_,_> (k, model.items.[k], m.Model) dispatch { attr.empty() }
             | Lazy (x, y) -> viewLazy (x, y) model dispatch
             | Virtual -> viewVirtual model dispatch
+            | NotFound -> p { text "Not found" }
     }
 
 type MyApp() =

--- a/tests/Remoting.Client/Main.fs
+++ b/tests/Remoting.Client/Main.fs
@@ -144,9 +144,11 @@ let router : Router<Page, Model, Message> =
             | Custom i -> $"/custom/{i}"
         setRoute = fun s ->
             match s.Trim('/').Split('/') with
-            | [|""|] -> Some (SetPage Home)
-            | [|"custom"; i|] -> Some (SetPage (Custom (int i)))
+            | [|""|] -> Some Home
+            | [|"custom"; i|] -> Some (Custom (int i))
             | _ -> None
+        makeMessage = SetPage
+        notFound = None
     }
 
 type Tpl = Template<"main.html">

--- a/tests/Unit.Client/Routing.fs
+++ b/tests/Unit.Client/Routing.fs
@@ -26,6 +26,7 @@ open Elmish
 
 type Page =
     | [<EndPoint "/">] Home
+    | [<EndPoint "/not-found">] NotFound
     | [<EndPoint "/no-arg">] NoArg
     | [<EndPoint "/with-arg">] WithArg of string
     | [<EndPoint "/with-args">] WithArgs of string * int
@@ -80,7 +81,9 @@ let update msg model =
     | SetPage p -> { model with page = p }
 
 let router =
-    try Router.infer SetPage (fun m -> m.page)
+    try
+        Router.infer SetPage (fun m -> m.page)
+        |> Router.withNotFound NotFound
     with e ->
         eprintfn $"ROUTER ERROR: {e}"
         reraise()
@@ -93,6 +96,7 @@ let innerPageClass = function
 
 let rec pageClass = function
     | Home -> "home"
+    | NotFound -> "notfound"
     | NoArg -> "noarg"
     | WithArg x -> $"witharg-{x}"
     | WithArgs(x, y) -> $"withargs-{x}-{y}"
@@ -192,6 +196,11 @@ let view model dispatch =
                 on.click (fun _ -> dispatch (SetPage page))
                 url
             }
+        a {
+            attr.``class`` "link-notfound"
+            attr.href "/invalid-url"
+            "/not-found"
+        }
         span { attr.``class`` "current-page"; $"{model.page}" }
     }
 

--- a/tests/Unit/Fixture.fs
+++ b/tests/Unit/Fixture.fs
@@ -152,7 +152,7 @@ and NodeFixture(parent: unit -> IWebElement, by: By) =
 
     /// Assert that the given value is eventually non-null.
     member this.EventuallyNotNull(expr: Expr<'T>) =
-        this.Eventually <@ isNotNull %expr @>
+        this.Wait(fun () -> eval expr)
 
 [<AutoOpen>]
 module Extensions =

--- a/tests/Unit/Tests/Html.fs
+++ b/tests/Unit/Tests/Html.fs
@@ -45,11 +45,11 @@ module Html =
         inp.Clear()
 
         inp.SendKeys("ab")
-        elt.EventuallyNotNull <@ elt.ByClass("condBoolIs2") @>
+        elt.EventuallyNotNull <@ elt.ByClass("condBoolIs2") @> |> ignore
         testNull <@ elt.ByClass("condBoolIsNot2") @>
 
         inp.SendKeys("c")
-        elt.EventuallyNotNull <@ elt.ByClass("condBoolIsNot2") @>
+        elt.EventuallyNotNull <@ elt.ByClass("condBoolIsNot2") @> |> ignore
         testNull <@ elt.ByClass("condBoolIs2") @>
 
     [<Test>]
@@ -57,17 +57,17 @@ module Html =
         let inp = elt.ByClass("condUnionInput")
         inp.Clear()
 
-        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsEmpty") @>
+        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsEmpty") @> |> ignore
         testNull <@ elt.ByClass("condUnionIsOne") @>
         testNull <@ elt.ByClass("condUnionIsMany") @>
 
         inp.SendKeys("a")
-        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsOne") @>
+        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsOne") @> |> ignore
         testNull <@ elt.ByClass("condUnionIsEmpty") @>
         testNull <@ elt.ByClass("condUnionIsMany") @>
 
         inp.SendKeys("b")
-        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsMany") @>
+        elt.EventuallyNotNull <@ elt.ByClass("condUnionIsMany") @> |> ignore
         testNull <@ elt.ByClass("condUnionIsOne") @>
         testNull <@ elt.ByClass("condUnionIsEmpty") @>
 
@@ -77,7 +77,7 @@ module Html =
         inp.Clear()
 
         inp.SendKeys("ABC")
-        elt.EventuallyNotNull <@ elt.ByClass("forEachIsA") @>
+        elt.EventuallyNotNull <@ elt.ByClass("forEachIsA") @> |> ignore
         testNotNull <@ elt.ByClass("forEachIsB") @>
         testNotNull <@ elt.ByClass("forEachIsC") @>
 
@@ -92,7 +92,7 @@ module Html =
         inp.Clear()
 
         inp.SendKeys("ABC")
-        elt.EventuallyNotNull <@ elt.ByClass("forLoopIsA") @>
+        elt.EventuallyNotNull <@ elt.ByClass("forLoopIsA") @> |> ignore
         testNotNull <@ elt.ByClass("forLoopIsB") @>
         testNotNull <@ elt.ByClass("forLoopIsC") @>
 

--- a/tests/Unit/Tests/Routing.fs
+++ b/tests/Unit/Tests/Routing.fs
@@ -30,14 +30,22 @@ module Routing =
     [<Test; TestCaseSource("links"); NonParallelizable>]
     let ``Click link``(linkCls: string, url: string, print: string) =
         elt.ByClass("link-" + linkCls).Click()
-        elt.Eventually <@ elt.ByClass("current-page").Text = print @>
+        let currentPage = elt.EventuallyNotNull <@ elt.ByClass("current-page") @>
+        elt.Eventually <@ currentPage.Text = print @>
         test <@ WebFixture.Driver.Url = WebFixture.Url + url @>
 
     [<Test; TestCaseSource("links"); NonParallelizable>]
     let ``Set by model``(linkCls: string, url: string, print: string) =
         elt.ByClass("btn-" + linkCls).Click()
-        elt.Eventually <@ elt.ByClass("current-page").Text = print @>
+        let currentPage = elt.EventuallyNotNull <@ elt.ByClass("current-page") @>
+        elt.Eventually <@ currentPage.Text = print @>
         test <@ WebFixture.Driver.Url = WebFixture.Url + url @>
+
+    [<Test; NonParallelizable>]
+    let ``Not found``() =
+        elt.ByClass("link-notfound").Click()
+        let currentPage = elt.EventuallyNotNull <@ elt.ByClass("current-page") @>
+        elt.Eventually <@ currentPage.Text = "NotFound" @>
 
     let failingRouter<'T> (expectedError: UnionCaseInfo[] -> InvalidRouterKind) =
         TestCaseData(


### PR DESCRIPTION
Fixes #308.

Example use:

```fsharp
type Page =
    | [<EndPoint "/">] Home
    | [<EndPoint "/not-found">] NotFound

type Model =
    { page: Page }

type Message =
    | PageChanged of Page

let router =
    Router.infer PageChanged (fun m -> m.page)
    |> Router.withNotFound NotFound
```

This will send the message `PageChanged NotFound`
* during initialization (before first display) if the URL couldn't be parsed;
* after the URL was programmatically set to a value that can't be parsed.

It does not change the behavior when the user clicks a link to a URL that can't be parsed: these are considered external links, and standard navigation is performed.

## Breaking changes

* The interface `IRouter<'model, 'msg>` has an additional property `NotFound: 'msg option`.
* The record `Router<'endpoint, 'model, 'msg>` has 
    * additional field `makeMessage: 'endpoint -> 'msg`;
    * additional field `notFound: 'endpoint option`;
    * type of field `setRoute` has changed to `string -> 'endpoint option` instead of `string -> 'msg option`.

These should be transparent for most users.