### PR TITLE
Routing: support adding anchors

### DIFF
--- a/src/Bolero/Router.fs
+++ b/src/Bolero/Router.fs
@@ -89,7 +89,11 @@ type Router<'ep, 'model, 'msg> =
     }
 
     /// <summary>Get the uri for the given <paramref name="endpoint" />.</summary>
-    member this.Link(endpoint) = this.getRoute endpoint
+    member this.Link(endpoint, [<Optional>] hash: string) =
+        let link = this.getRoute endpoint
+        match hash with
+        | null -> link
+        | hash -> link + "#" + hash
 
     interface IRouter<'model, 'msg> with
         member this.GetRoute(model) = this.getRoute (this.getEndPoint model)
@@ -959,7 +963,8 @@ type RouterExtensions =
     /// <summary>Create an HTML href attribute pointing to the given endpoint.</summary>
     /// <param name="this">The router.</param>
     /// <param name="endpoint">The router endpoint.</param>
+    /// <param name="hash">The hash part of the URL, to scroll to the element with this id.</param>
     /// <returns>An <c>href</c> attribute pointing to the given endpoint.</returns>
     [<Extension>]
-    static member HRef(this: Router<'ep, _, _>, endpoint: 'ep) : Attr =
-        Attr.Make "href" (this.Link endpoint)
+    static member HRef(this: Router<'ep, _, _>, endpoint: 'ep, [<Optional>] hash: string) : Attr =
+        Attr.Make "href" (this.Link(endpoint, hash))

--- a/tests/Client/Main.fs
+++ b/tests/Client/Main.fs
@@ -351,6 +351,9 @@ let view js model dispatch =
             | Lazy (x, y) -> viewLazy (x, y) model dispatch
             | Virtual -> viewVirtual model dispatch
             | NotFound -> p { text "Not found" }
+        div { a { attr.href (router.Link Collection + "#page-bottom"); "Go to bottom" } }
+        div { attr.style "height: 2000px;" }
+        div { attr.id "page-bottom"; text "Page bottom!" }
     }
 
 type MyApp() =

--- a/tests/Unit.Client/Routing.fs
+++ b/tests/Unit.Client/Routing.fs
@@ -27,6 +27,7 @@ open Elmish
 type Page =
     | [<EndPoint "/">] Home
     | [<EndPoint "/not-found">] NotFound
+    | [<EndPoint "/with-anchor">] WithAnchor
     | [<EndPoint "/no-arg">] NoArg
     | [<EndPoint "/with-arg">] WithArg of string
     | [<EndPoint "/with-args">] WithArgs of string * int
@@ -97,6 +98,7 @@ let innerPageClass = function
 let rec pageClass = function
     | Home -> "home"
     | NotFound -> "notfound"
+    | WithAnchor -> "withanchor"
     | NoArg -> "noarg"
     | WithArg x -> $"witharg-{x}"
     | WithArgs(x, y) -> $"withargs-{x}-{y}"
@@ -202,6 +204,24 @@ let view model dispatch =
             "/not-found"
         }
         span { attr.``class`` "current-page"; $"{model.page}" }
+        div {
+            a {
+                attr.``class`` "link-to-anchor"
+                router.HRef(WithAnchor, "the-anchor")
+                "go to anchor"
+            }
+        }
+        cond model.page <| function
+            | WithAnchor ->
+                concat {
+                    div { attr.style "height: 3000px" }
+                    div {
+                        attr.id "the-anchor"
+                        attr.style "height: 3000px"
+                        "the anchor"
+                    }
+                }
+            | _ -> empty()
     }
 
 type Test() =


### PR DESCRIPTION
Fixes #315: links to a routed page with a hash now correctly scroll the linked element into view.

Adds an optional argument `hash: string` to `Router.Link()` and `Router.HRef()`.