### PR TITLE
Update target frameworks in Bolero.Html.fsproj

### DIFF
--- a/src/Bolero.Html/Bolero.Html.fsproj
+++ b/src/Bolero.Html/Bolero.Html.fsproj
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <RootNamespace>Bolero</RootNamespace>
     <IsTrimmable>true</IsTrimmable>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Trimmable.fs" Link="Trimmable.fs" />


### PR DESCRIPTION
The project file for Bolero.Html has been updated to include both .NET 6.0 and .NET 8.0 as target frameworks. This extends compatibility and support for the library across these versions.

This should fix the issue #330 