### PR TITLE
Enable interactive render modes

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -32,6 +32,7 @@ nuget FSharp.Core >= 6.0 content: none
 nuget Elmish >= 4.0.1 < 5.0
 nuget Microsoft.AspNetCore.Components.WebAssembly >= 8.0.0
 nuget Microsoft.JSInterop.WebAssembly >= 8.0.0
+nuget Microsoft.AspNetCore.Components >= 8.0.0
 nuget Microsoft.AspNetCore.Components.Web >= 8.0.0
 nuget Microsoft.Extensions.Http >= 8.0.0
 nuget FSharp.SystemTextJson >= 0.19.13

--- a/src/Bolero.Server/Extensions.fs
+++ b/src/Bolero.Server/Extensions.fs
@@ -88,7 +88,9 @@ type ServerComponentsExtensions =
     static member RenderBoleroScript(html: IHtmlHelper, config: IBoleroHostConfig) =
         html.Raw(BoleroHostConfig.Body(config))
 
-    /// <summary>Configure the hosting of server-side and WebAssembly Bolero components.</summary>
+    /// <summary>
+    /// Configure the hosting of server-side and WebAssembly Bolero components using Bolero's legacy render mode handling.
+    /// </summary>
     /// <param name="server">If true, use server-side Bolero; if false, use WebAssembly. Default is false.</param>
     /// <param name="prerendered">If true, prerender the initial view in the served HTML. Default is true.</param>
     /// <param name="devToggle">
@@ -111,8 +113,20 @@ type ServerComponentsExtensions =
         else
             this.AddSingleton(
                 { new IBoleroHostConfig with
+                    member _.IsInteractiveRender = false
                     member _.IsServer = server
                     member _.IsPrerendered = prerendered })
+
+    /// <summary>
+    /// Configure the hosting of Bolero components using interactive render modes.
+    /// </summary>
+    [<Extension>]
+    static member AddBoleroComponents(this: IServiceCollection) =
+        this.AddSingleton(
+            { new IBoleroHostConfig with
+                member _.IsInteractiveRender = true
+                member _.IsServer = false
+                member _.IsPrerendered = false })
 
     /// <summary>
     /// Adds a route endpoint that will match requests for non-file-names with the lowest possible priority.

--- a/src/Bolero.Server/Html.fs
+++ b/src/Bolero.Server/Html.fs
@@ -128,3 +128,12 @@ module Html =
     /// preceded by the standard "html" doctype declaration.
     /// </summary>
     let doctypeHtml = DoctypeHtmlBuilder()
+
+#if NET8_0_OR_GREATER
+    module attr =
+
+        let renderMode (mode: IComponentRenderMode) =
+            Attr(fun _ b i ->
+                b.AddComponentRenderMode(mode)
+                i)
+#endif

--- a/src/Bolero.Server/Html.fs
+++ b/src/Bolero.Server/Html.fs
@@ -130,8 +130,18 @@ module Html =
     let doctypeHtml = DoctypeHtmlBuilder()
 
 #if NET8_0_OR_GREATER
+    /// HTML attributes.
     module attr =
 
+        /// <summary>
+        /// Define the render mode to use for this component.
+        /// Must be used on a component in a server-side page that uses interactive render modes.
+        /// </summary>
+        /// <param name="mode">
+        /// The render mode.
+        /// Usually one of the modes defined in <see cref="T:Microsoft.AspNetCore.Components.Web.RenderMode"/>.
+        /// </param>
+        /// <seealso cref="M:Bolero.Server.ServerComponentsExtensions.AddBoleroComponents(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>
         let renderMode (mode: IComponentRenderMode) =
             Attr(fun _ b i ->
                 b.AddComponentRenderMode(mode)

--- a/src/Bolero/Bolero.fsproj
+++ b/src/Bolero/Bolero.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Router.fs" />
     <Compile Include="ProgramRun.fs" />
     <Compile Include="Components.fs" />
+    <Compile Include="RenderMode.fs" />
     <Compile Include="Attr.fs" />
     <Compile Include="Node.fs" />
     <Compile Include="Virtualize.fs" />

--- a/src/Bolero/RenderMode.fs
+++ b/src/Bolero/RenderMode.fs
@@ -1,0 +1,42 @@
+namespace Bolero
+#if NET8_0_OR_GREATER
+
+open System.Runtime.InteropServices
+open Microsoft.AspNetCore.Components
+open Microsoft.AspNetCore.Components.Web
+
+type BoleroRenderMode =
+    /// <summary>
+    /// Render the component and run its interactivity on the server side.
+    /// </summary>
+    | Server = 1
+    /// <summary>
+    /// Render the component and run its interactivity on the client side.
+    /// </summary>
+    | WebAssembly = 2
+    /// <summary>
+    /// Automatically decide where to render the component and run its interactivity.
+    /// </summary>
+    | Auto = 3
+
+/// <summary>
+/// Define how a component is rendered in interactive render mode.
+/// </summary>
+type BoleroRenderModeAttribute
+    /// <summary>
+    /// Define how a component is rendered in interactive render mode.
+    /// </summary>
+    /// <param name="mode">The render mode.</param>
+    /// <param name="prerender">Whether to prerender the component in the HTML response.</param>
+    (mode, [<Optional; DefaultParameterValue true>] prerender: bool) =
+    inherit RenderModeAttribute()
+
+    /// <inheritdoc />
+    override val Mode : IComponentRenderMode =
+        match mode with
+        | BoleroRenderMode.Server -> InteractiveServerRenderMode(prerender)
+        | BoleroRenderMode.WebAssembly -> InteractiveWebAssemblyRenderMode(prerender)
+        | BoleroRenderMode.Auto -> InteractiveAutoRenderMode(prerender)
+        | _ -> failwith $"Invalid InteractiveRenderMode: {mode}"
+
+#endif

--- a/src/Bolero/paket.references
+++ b/src/Bolero/paket.references
@@ -8,6 +8,7 @@ FSharp.SystemTextJson
 
 group net8
 Elmish
+Microsoft.AspNetCore.Components
 Microsoft.AspNetCore.Components.WebAssembly
 Microsoft.JSInterop.WebAssembly
 Microsoft.Extensions.Http

--- a/tests/Remoting.Client/Main.fs
+++ b/tests/Remoting.Client/Main.fs
@@ -21,7 +21,6 @@
 module Bolero.Tests.Remoting.Client
 
 open System.Collections.Generic
-open Microsoft.AspNetCore.Components
 open Microsoft.AspNetCore.Components.Authorization
 open Bolero
 open Bolero.Html
@@ -221,7 +220,6 @@ let Display model dispatch =
         }
     }
 
-[<BoleroRenderMode(BoleroRenderMode.Auto); Route "/{*path}">]
 type MyApp() =
     inherit ProgramComponent<Model, Message>()
 

--- a/tests/Remoting.Client/Main.fs
+++ b/tests/Remoting.Client/Main.fs
@@ -21,6 +21,7 @@
 module Bolero.Tests.Remoting.Client
 
 open System.Collections.Generic
+open Microsoft.AspNetCore.Components
 open Microsoft.AspNetCore.Components.Authorization
 open Bolero
 open Bolero.Html
@@ -220,6 +221,7 @@ let Display model dispatch =
         }
     }
 
+[<BoleroRenderMode(BoleroRenderMode.Auto); Route "/{*path}">]
 type MyApp() =
     inherit ProgramComponent<Model, Message>()
 

--- a/tests/Remoting.Server/Startup.fs
+++ b/tests/Remoting.Server/Startup.fs
@@ -35,6 +35,8 @@ open Bolero.Server
 open FSharp.SystemTextJson.Swagger
 
 module Page =
+    open Microsoft.AspNetCore.Components
+    open Microsoft.AspNetCore.Components.Web
     open Bolero.Html
     open Bolero.Server.Html
 
@@ -45,12 +47,13 @@ module Page =
             ``base`` { attr.href "/" }
         }
         body {
-            div { attr.id "main"; comp<MyApp> }
+            div { attr.id "main"; comp<MyApp> { attr.renderMode RenderMode.InteractiveAuto } }
             script { attr.src "_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js" }
             boleroScript
         }
     }
 
+    [<Route "/{*path}">]
     type Page() =
         inherit Bolero.Component()
         override _.Render() = index


### PR DESCRIPTION
Partial implementation for #347.

* Add `BoleroRenderModeAttribute` to conveniently define the render mode of a component.
* Add `IServiceCollection.AddBoleroComponents()` as the interactive render mode counterpart of `IServiceCollection.AddBoleroHost()`.
* Switch the sample project `tests/Remoting.{Client,Server}` to use interactive mode.