### PR TITLE
Add facilities for StreamRendering

### DIFF
--- a/src/Bolero/ProgramRun.fs
+++ b/src/Bolero/ProgramRun.fs
@@ -105,8 +105,17 @@ module internal Program' =
 
         reentered <- true
         setState model dispatch
-        fun () ->
+        let mutable cmd = cmd
+
+        let updateInitState m cmd' =
+            setState m dispatch
+            state <- m
+            cmd <- cmd @ cmd'
+
+        let run () =
             cmd |> Cmd.exec (fun ex -> onError ("Error intitializing:", ex)) dispatch
             activeSubs <- Subs.diff activeSubs sub |> Subs.Fx.change onError dispatch
             processMsgs ()
             reentered <- false
+
+        updateInitState, model, run


### PR DESCRIPTION
* `Program.mkStreamRendering`, similar to `Program.mkProgram` except instead of an init function, it takes an initial model and a load function that returns a task.
* `Program.mkSimpleStreamRendering`, similarly based on `Program.mkSimple`.